### PR TITLE
`stbt.hold` to emulate holding down a button on the remote control

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -309,6 +309,30 @@ press(key)
     `key` is a string. The allowed values depend on the control you're using:
     If that's lirc, then `key` is a key name from your lirc config file.
 
+hold(key)
+    Context manager that sends key-down/key-up to the system under test.
+
+    Currently this is only implemented for the LIRC control mechanism.
+
+    Example usage:
+
+        with stbt.hold("RIGHT"):
+            stbt.wait_for_match("last-page.png")
+
+    For infrared (LIRC) controls, this is implemented by continuously sending
+    the infrared repeat signal. In some infrared protocols this is the same as
+    sending the initial key-press signal repeatedly; for other protocols, the
+    repeat signal differs from the initial signal. Your LIRC configuration must
+    specify the correct initial & repeat signals for your particular system
+    under test. See section 9 ("An Introduction to Remote Control Signals") of
+    http://redrat.co.uk/products/IRNetBox_Comms-V3.X.pdf , and
+    http://winlirc.sourceforge.net/technicaldetails.html#fileformat.
+
+    Note that with infrared-based control mechanisms you can't use ``press``
+    inside the ``hold`` context, because you can't send two different infrared
+    signals simultaneously (``press`` will raise an exception if you try to do
+    this).
+
 wait_for_match(image, timeout_secs=10, consecutive_matches=1, noise_threshold=None, match_parameters=None)
     Search for `image` in the source video stream.
 

--- a/api-doc.sh
+++ b/api-doc.sh
@@ -60,6 +60,7 @@ substitute_python_docstrings() {
 python_docstrings() {
     echo ""
     doc press
+    doc hold
     doc wait_for_match
     doc press_until_match
     doc wait_for_motion

--- a/stbt.py
+++ b/stbt.py
@@ -140,6 +140,7 @@ def press(key):
     draw_text(key, duration_secs=3)
 
 
+@contextlib.contextmanager
 def hold(key):
     """Context manager that sends key-down/key-up to the system under test.
 
@@ -164,7 +165,10 @@ def hold(key):
     signals simultaneously (``press`` will raise an exception if you try to do
     this).
     """
-    return _control.hold(key)
+    draw_text("Holding %s" % key)
+    with _control.hold(key):
+        yield
+    draw_text("Releasing %s" % key)
 
 
 def draw_text(text, duration_secs=3):

--- a/stbt.py
+++ b/stbt.py
@@ -1524,9 +1524,7 @@ class VirtualRemote:
 
     @contextlib.contextmanager
     def hold(self, key):
-        self._connect().sendall('D\t%s\n\x00' % key)  # key Down
-        yield
-        self._connect().sendall('U\t%s\n\x00' % key)  # key Up
+        raise NotImplementedError('VirtualRemote: hold not implemented')
 
 
 class LircRemote:

--- a/stbt.py
+++ b/stbt.py
@@ -1546,10 +1546,12 @@ class LircRemote:
     @contextlib.contextmanager
     def hold(self, key):
         s = self._connect()
-        s.sendall('SEND_START %s %s\n' % (self.control_name, key))
-        yield
-        s.sendall('SEND_STOP %s %s\n' % (self.control_name, key))
-        s.close()
+        try:
+            s.sendall('SEND_START %s %s\n' % (self.control_name, key))
+            yield
+        finally:
+            s.sendall('SEND_STOP %s %s\n' % (self.control_name, key))
+            s.close()
 
 
 def new_local_lirc_remote(lircd_socket, control_name):

--- a/stbt.py
+++ b/stbt.py
@@ -1549,9 +1549,7 @@ class LircRemote:
     def hold(self, key):
         s = self._connect()
         s.sendall('SEND_START %s %s\n' % (self.control_name, key))
-        s.close()
         yield
-        s = self._connect()
         s.sendall('SEND_STOP %s %s\n' % (self.control_name, key))
         s.close()
 

--- a/stbt.py
+++ b/stbt.py
@@ -141,6 +141,29 @@ def press(key):
 
 
 def hold(key):
+    """Context manager that sends key-down/key-up to the system under test.
+
+    Currently this is only implemented for the LIRC control mechanism.
+
+    Example usage:
+
+        with stbt.hold("RIGHT"):
+            stbt.wait_for_match("last-page.png")
+
+    For infrared (LIRC) controls, this is implemented by continuously sending
+    the infrared repeat signal. In some infrared protocols this is the same as
+    sending the initial key-press signal repeatedly; for other protocols, the
+    repeat signal differs from the initial signal. Your LIRC configuration must
+    specify the correct initial & repeat signals for your particular system
+    under test. See section 9 ("An Introduction to Remote Control Signals") of
+    http://redrat.co.uk/products/IRNetBox_Comms-V3.X.pdf , and
+    http://winlirc.sourceforge.net/technicaldetails.html#fileformat.
+
+    Note that with infrared-based control mechanisms you can't use ``press``
+    inside the ``hold`` context, because you can't send two different infrared
+    signals simultaneously (``press`` will raise an exception if you try to do
+    this).
+    """
     return _control.hold(key)
 
 

--- a/tests/fake-lircd
+++ b/tests/fake-lircd
@@ -51,7 +51,7 @@ def response(req):
         s += "BEGIN\nSIGHUP\nEND\n"
     if re.search("broadcast", req):
         s += "000f00b 01 OK My-IR-remote\n"
-    if req.startswith("SEND_ONCE"):
+    if re.search("^SEND_ONCE|SEND_START|SEND_STOP", req):
         if re.search("error", req):
             s += "BEGIN\n%s\nERROR\nDATA\n1\nfake-lircd error\nEND\n" % req
         elif re.search("timeout", req):

--- a/tests/test-lirc.sh
+++ b/tests/test-lirc.sh
@@ -82,3 +82,17 @@ test_that_press_ignores_lircd_broadcast_messages_on_no_reply() {
     [ $? -eq $timedout ] && fail "'press' timed out"
     [ $? -ne 0 ] || fail "Expected 'press' to raise exception"
 }
+
+test_hold_with_lirc() {
+    start_fake_lircd
+
+    cat > test.py <<-EOF &&
+	import stbt
+	with stbt.hold("left"):
+	    pass
+	EOF
+    stbt-run -v --control lirc:$lircd_socket:test test.py || return
+    grep -q "fake-lircd: Received: SEND_START test left" fake-lircd.log &&
+    grep -q "fake-lircd: Received: SEND_STOP test left" fake-lircd.log ||
+        fail "fake-lircd didn't receive SEND_START and SEND_STOP messages"
+}


### PR DESCRIPTION
For background see the discussion on the mailing list:
https://groups.google.com/forum/#!topic/stb-tester/fvdWw8o_EjA

I'm not sure if this API for `stbt.hold` is a good idea, given that it
will be quite difficult to implement for the RedRat irNetBox unless
RedRat implement additional functionality. I suppose we could launch a
separate thread that sends lots of individual keypresses and hope that's
good enough (it will only work for infrared protocols where the initial
& repeat signals are the same). We might even have to do the same for
the LIRC implementation, given that LIRC's repeat sending doesn't work
inside a VM, at least not for me.
