### PR TITLE
Rename stbt.UITestFailure => stbt.TestFailure; deprecate UITestError

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -317,16 +317,16 @@ The following functions are available:
 .. <start python docs>
 
 as_precondition(message)
-    Context manager that replaces TestFailures with TestErrors.
+    Context manager that replaces test failures with test errors.
 
     If you run your test scripts with stb-tester's batch runner, the reports it
-    generates will show test failures (that is, `TestFailure` exceptions) as
-    red results, and unhandled exceptions of any other type as yellow results.
-    Note that `wait_for_match`, `wait_for_motion`, and similar functions raise
-    `TestFailure` (red results) when they detect a failure. By running such
-    functions inside an `as_precondition` context, any `TestFailure` (red)
-    they raise will be caught, and a `TestError` (yellow) will be raised
-    instead.
+    generates will show test failures (that is, `stbt.TestFailure` exceptions)
+    as red results, and unhandled exceptions of any other type as yellow
+    results. Note that `wait_for_match`, `wait_for_motion`, and similar
+    functions raise `stbt.TestFailure` (red results) when they detect a
+    failure. By running such functions inside an `as_precondition` context, any
+    `stbt.TestFailure` (red) they raise will be caught, and a
+    `stbt.PreconditionError` (yellow) will be raised instead.
 
     When running a single test script hundreds or thousands of times to
     reproduce an intermittent defect, it is helpful to mark unrelated failures
@@ -665,7 +665,7 @@ class Position
     `x` and `y` are integer coordinates (measured in number of pixels) from the
     top left corner of the video frame.
 
-class PreconditionError(TestError)
+class PreconditionError(Exception)
     Exception raised by `as_precondition`.
 
 press(key, interpress_delay_secs=None)
@@ -779,9 +779,6 @@ save_frame(image, filename)
 
     Takes an image obtained from `get_frame` or from the `screenshot`
     property of `MatchTimeout` or `MotionTimeout`.
-
-class TestError(Exception)
-    The test script had an unrecoverable error.
 
 class TestFailure(Exception)
     The test failed because the system under test didn't behave as expected.

--- a/README.rst
+++ b/README.rst
@@ -210,7 +210,7 @@ EXIT STATUS
 0 on success; 1 on test script failure; 2 on any other error.
 
 Test scripts indicate **failure** (the system under test didn't behave as
-expected) by raising an instance of `stbt.UITestFailure` (or a subclass
+expected) by raising an instance of `stbt.TestFailure` (or a subclass
 thereof). Any other exception is considered a test **error** (a logic error in
 the test script, an error in the system under test's environment, or an error
 in the test framework itself).
@@ -317,15 +317,15 @@ The following functions are available:
 .. <start python docs>
 
 as_precondition(message)
-    Context manager that replaces UITestFailures with UITestErrors.
+    Context manager that replaces TestFailures with TestErrors.
 
     If you run your test scripts with stb-tester's batch runner, the reports it
-    generates will show test failures (that is, `UITestFailure` exceptions) as
+    generates will show test failures (that is, `TestFailure` exceptions) as
     red results, and unhandled exceptions of any other type as yellow results.
     Note that `wait_for_match`, `wait_for_motion`, and similar functions raise
-    `UITestFailure` (red results) when they detect a failure. By running such
-    functions inside an `as_precondition` context, any `UITestFailure` (red)
-    they raise will be caught, and a `UITestError` (yellow) will be raised
+    `TestFailure` (red results) when they detect a failure. By running such
+    functions inside an `as_precondition` context, any `TestFailure` (red)
+    they raise will be caught, and a `TestError` (yellow) will be raised
     instead.
 
     When running a single test script hundreds or thousands of times to
@@ -341,7 +341,7 @@ as_precondition(message)
 
     >>> with as_precondition("Channels tuned"):  #doctest:+NORMALIZE_WHITESPACE
     ...     # Call tune_channels(), which raises:
-    ...     raise UITestFailure("Failed to tune channels")
+    ...     raise TestFailure("Failed to tune channels")
     Traceback (most recent call last):
       ...
     PreconditionError: Didn't meet precondition 'Channels tuned'
@@ -586,7 +586,7 @@ class MatchResult
     * `position`: `Position` of the match, the same as in `region`. Included
       for backwards compatibility; we recommend using `region` instead.
 
-class MatchTimeout(UITestFailure)
+class MatchTimeout(TestFailure)
     * `screenshot`: An OpenCV image from the source video when the search
       for the expected image timed out.
     * `expected`: Filename of the image that was being searched for.
@@ -596,13 +596,13 @@ class MotionResult
     * `timestamp`: Video stream timestamp.
     * `motion`: Boolean result.
 
-class MotionTimeout(UITestFailure)
+class MotionTimeout(TestFailure)
     * `screenshot`: An OpenCV image from the source video when the search
       for motion timed out.
     * `mask`: Filename of the mask that was used (see `wait_for_motion`).
     * `timeout_secs`: Number of seconds that motion was searched for.
 
-class NoVideo(UITestFailure)
+class NoVideo(TestFailure)
     No video available from the source pipeline.
 
 ocr(frame=None, region=Region.ALL, mode=OcrMode.PAGE_SEGMENTATION_WITHOUT_OSD, lang=None, tesseract_config=None, tesseract_user_words=None, tesseract_user_patterns=None)
@@ -665,7 +665,7 @@ class Position
     `x` and `y` are integer coordinates (measured in number of pixels) from the
     top left corner of the video frame.
 
-class PreconditionError(UITestError)
+class PreconditionError(TestError)
     Exception raised by `as_precondition`.
 
 press(key, interpress_delay_secs=None)
@@ -780,6 +780,12 @@ save_frame(image, filename)
     Takes an image obtained from `get_frame` or from the `screenshot`
     property of `MatchTimeout` or `MotionTimeout`.
 
+class TestError(Exception)
+    The test script had an unrecoverable error.
+
+class TestFailure(Exception)
+    The test failed because the system under test didn't behave as expected.
+
 class TextMatchResult
     Return type of `match_text`.
 
@@ -788,12 +794,6 @@ class TextMatchResult
     region (Region): The bounding box of the text found or None if no text found
     frame: The video frame matched against
     text (unicode): The text searched for
-
-class UITestError(Exception)
-    The test script had an unrecoverable error.
-
-class UITestFailure(Exception)
-    The test failed because the system under test didn't behave as expected.
 
 wait_for_match(image, timeout_secs=10, consecutive_matches=1, noise_threshold=None, match_parameters=None)
     Search for `image` in the source video stream.

--- a/api-doc.sh
+++ b/api-doc.sh
@@ -27,9 +27,9 @@ doc() {
     #  |  Method resolution order:
     #  ...
 
-    # $ pydoc stbt.TestError
-    # stbt.TestError = class TestError(exceptions.Exception)
-    #  |  The test script had an unrecoverable error.
+    # $ pydoc stbt.TestFailure
+    # stbt.TestFailure = class TestFailure(exceptions.Exception)
+    #  |  The test failed because the system under test didn't behave as expected.
     #  |  
     #  |  Method resolution order:
     #  ...

--- a/api-doc.sh
+++ b/api-doc.sh
@@ -27,8 +27,8 @@ doc() {
     #  |  Method resolution order:
     #  ...
 
-    # $ pydoc stbt.UITestError
-    # stbt.UITestError = class UITestError(exceptions.Exception)
+    # $ pydoc stbt.TestError
+    # stbt.TestError = class TestError(exceptions.Exception)
     #  |  The test script had an unrecoverable error.
     #  |  
     #  |  Method resolution order:

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -29,10 +29,30 @@ For installation instructions see
 
   This is the same (sensible) behaviour that Python 3 has by default.
 
+* API: The `stbt.Precondition` exception now inherits from `Exception`, not
+  `stbt.UITestError`. See the `UITestError` deprecation in the next section for
+  more details.
+
 ##### User-visible changes since 0.21
 
 * API: `is_frame_black()` now no longer requires a frame to be passed in.  If
   one is not specified it will be grabbed from live video, much like `match()`.
+
+* API: `UITestFailure` has been renamed to `TestFailure`, for reasons of
+  simplifying our terminology. The old name remains as an alias for backwards
+  compatibility.
+
+* API: `UITestError` is deprecated. Use any user-defined or built-in exception
+  instead; anything that isn't a `TestFailure` exception is treated as a test
+  error (test errors show up as yellow in the `stbt batch` report instead of
+  red). If you can't find a suitable exception, use `RuntimeError`.
+
+  This change simplifies our API; most stbt functions already raised built-in
+  exceptions anyway (because they call functions from the python standard
+  library and from third-party libraries, and they don't catch all possible
+  exceptions to translate them to `UITestError`s). There is no change to the
+  way `stbt run` or `stbt batch run` handle user-defined or built-in
+  exceptions; they were already treated as test errors.
 
 ##### Bugfixes and packaging fixes since 0.21
 

--- a/stbt-run
+++ b/stbt-run
@@ -67,7 +67,7 @@ except Exception as e:  # pylint: disable=W0703
         stbt.save_frame(e.screenshot, "screenshot.png")
         sys.stderr.write("Saved screenshot to '%s'.\n" % ("screenshot.png"))
     traceback.print_exc(file=sys.stderr)
-    if isinstance(e, stbt.UITestFailure):
+    if isinstance(e, stbt.TestFailure):
         sys.exit(1)  # Failure
     else:
         sys.exit(2)  # Error

--- a/stbt-templatematch
+++ b/stbt-templatematch
@@ -78,5 +78,5 @@ with (stbt.logging.scoped_debug_level(2) if args.verbose
             "Match found" if result else "No match found. Closest match",
             result)
         sys.exit(0 if result else 1)
-    except stbt.UITestError as e:
+    except stbt.TestError as e:
         error(e.message)

--- a/stbt-templatematch
+++ b/stbt-templatematch
@@ -78,5 +78,5 @@ with (stbt.logging.scoped_debug_level(2) if args.verbose
             "Match found" if result else "No match found. Closest match",
             result)
         sys.exit(0 if result else 1)
-    except stbt.TestError as e:
+    except Exception as e:  # pylint: disable=W0703
         error(e.message)

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -67,7 +67,6 @@ __all__ = [
     "press_until_match",
     "Region",
     "save_frame",
-    "TestError",
     "TestFailure",
     "TextMatchResult",
     "wait_for_match",
@@ -494,10 +493,11 @@ def _load_template(template):
     else:
         template_name = _find_path(template)
         if not os.path.isfile(template_name):
-            raise TestError("No such template file: %s" % template_name)
+            raise ValueError("No such template file: %s" % template_name)
         image = cv2.imread(template_name, cv2.CV_LOAD_IMAGE_COLOR)
         if image is None:
-            raise TestError("Failed to load template file: %s" % template_name)
+            raise RuntimeError(
+                "Failed to load template file: %s" % template_name)
         return _AnnotatedTemplate(image, template_name)
 
 
@@ -659,7 +659,7 @@ def detect_motion(timeout_secs=10, noise_threshold=None, mask=None):
         if previous_frame_gray is None:
             if (mask_image is not None and
                     mask_image.shape[:2] != frame_gray.shape[:2]):
-                raise TestError(
+                raise ValueError(
                     "The dimensions of the mask '%s' %s don't match the video "
                     "frame %s" % (mask, mask_image.shape, frame_gray.shape))
             previous_frame_gray = frame_gray
@@ -1327,16 +1327,16 @@ def is_screen_black(frame=None, mask=None, threshold=None):
 
 @contextmanager
 def as_precondition(message):
-    """Context manager that replaces TestFailures with TestErrors.
+    """Context manager that replaces test failures with test errors.
 
     If you run your test scripts with stb-tester's batch runner, the reports it
-    generates will show test failures (that is, `TestFailure` exceptions) as
-    red results, and unhandled exceptions of any other type as yellow results.
-    Note that `wait_for_match`, `wait_for_motion`, and similar functions raise
-    `TestFailure` (red results) when they detect a failure. By running such
-    functions inside an `as_precondition` context, any `TestFailure` (red)
-    they raise will be caught, and a `TestError` (yellow) will be raised
-    instead.
+    generates will show test failures (that is, `stbt.TestFailure` exceptions)
+    as red results, and unhandled exceptions of any other type as yellow
+    results. Note that `wait_for_match`, `wait_for_motion`, and similar
+    functions raise `stbt.TestFailure` (red results) when they detect a
+    failure. By running such functions inside an `as_precondition` context, any
+    `stbt.TestFailure` (red) they raise will be caught, and a
+    `stbt.PreconditionError` (yellow) will be raised instead.
 
     When running a single test script hundreds or thousands of times to
     reproduce an intermittent defect, it is helpful to mark unrelated failures
@@ -1372,7 +1372,14 @@ def as_precondition(message):
 
 class TestError(Exception):
     """The test script had an unrecoverable error."""
-    pass
+    def __init__(self, *args):
+        super(TestError, self).__init__(*args)
+        warnings.warn(
+            "'TestError' is deprecated and will be removed in a future "
+            "release of stb-tester. Please use a more descriptive exception "
+            "instead (any exception that isn't stbt.TestFailure, including "
+            "built-in exceptions, counts as a test error).",
+            DeprecationWarning, stacklevel=2)
 
 
 class TestFailure(Exception):
@@ -1427,7 +1434,7 @@ class MotionTimeout(TestFailure):
             self.timeout_secs)
 
 
-class PreconditionError(TestError):
+class PreconditionError(Exception):
     """Exception raised by `as_precondition`."""
     def __init__(self, message, original_exception):
         super(PreconditionError, self).__init__()
@@ -1730,7 +1737,7 @@ class Display(object):
                     pipeline, Gst.DebugGraphDetails.ALL, "NoVideo")
             raise NoVideo("No video")
         if isinstance(gst_sample, Exception):
-            raise TestError(str(gst_sample))
+            raise gst_sample
 
         return gst_sample
 
@@ -1846,7 +1853,7 @@ class Display(object):
             pipeline, Gst.DebugGraphDetails.ALL, "ERROR")
         err, dbg = message.parse_error()
         self.tell_user_thread(
-            TestError("%s: %s\n%s\n" % (err, err.message, dbg)))
+            RuntimeError("%s: %s\n%s\n" % (err, err.message, dbg)))
         _mainloop.quit()
 
     def on_warning(self, _bus, message):
@@ -2394,10 +2401,10 @@ def _load_mask(mask):
     mask_path = _find_path(mask)
     debug("Using mask %s" % mask_path)
     if not os.path.isfile(mask_path):
-        raise TestError("No such mask file: %s" % mask)
+        raise ValueError("No such mask file: %s" % mask)
     mask_image = cv2.imread(mask_path, cv2.CV_LOAD_IMAGE_GRAYSCALE)
     if mask_image is None:
-        raise TestError("Failed to load mask file: %s" % mask_path)
+        raise RuntimeError("Failed to load mask file: %s" % mask_path)
     return mask_image
 
 

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -67,9 +67,9 @@ __all__ = [
     "press_until_match",
     "Region",
     "save_frame",
+    "TestError",
+    "TestFailure",
     "TextMatchResult",
-    "UITestError",
-    "UITestFailure",
     "wait_for_match",
     "wait_for_motion",
 ]
@@ -494,11 +494,10 @@ def _load_template(template):
     else:
         template_name = _find_path(template)
         if not os.path.isfile(template_name):
-            raise UITestError("No such template file: %s" % template_name)
+            raise TestError("No such template file: %s" % template_name)
         image = cv2.imread(template_name, cv2.CV_LOAD_IMAGE_COLOR)
         if image is None:
-            raise UITestError("Failed to load template file: %s" %
-                              template_name)
+            raise TestError("Failed to load template file: %s" % template_name)
         return _AnnotatedTemplate(image, template_name)
 
 
@@ -660,7 +659,7 @@ def detect_motion(timeout_secs=10, noise_threshold=None, mask=None):
         if previous_frame_gray is None:
             if (mask_image is not None and
                     mask_image.shape[:2] != frame_gray.shape[:2]):
-                raise UITestError(
+                raise TestError(
                     "The dimensions of the mask '%s' %s don't match the video "
                     "frame %s" % (mask, mask_image.shape, frame_gray.shape))
             previous_frame_gray = frame_gray
@@ -1328,15 +1327,15 @@ def is_screen_black(frame=None, mask=None, threshold=None):
 
 @contextmanager
 def as_precondition(message):
-    """Context manager that replaces UITestFailures with UITestErrors.
+    """Context manager that replaces TestFailures with TestErrors.
 
     If you run your test scripts with stb-tester's batch runner, the reports it
-    generates will show test failures (that is, `UITestFailure` exceptions) as
+    generates will show test failures (that is, `TestFailure` exceptions) as
     red results, and unhandled exceptions of any other type as yellow results.
     Note that `wait_for_match`, `wait_for_motion`, and similar functions raise
-    `UITestFailure` (red results) when they detect a failure. By running such
-    functions inside an `as_precondition` context, any `UITestFailure` (red)
-    they raise will be caught, and a `UITestError` (yellow) will be raised
+    `TestFailure` (red results) when they detect a failure. By running such
+    functions inside an `as_precondition` context, any `TestFailure` (red)
+    they raise will be caught, and a `TestError` (yellow) will be raised
     instead.
 
     When running a single test script hundreds or thousands of times to
@@ -1352,7 +1351,7 @@ def as_precondition(message):
 
     >>> with as_precondition("Channels tuned"):  #doctest:+NORMALIZE_WHITESPACE
     ...     # Call tune_channels(), which raises:
-    ...     raise UITestFailure("Failed to tune channels")
+    ...     raise TestFailure("Failed to tune channels")
     Traceback (most recent call last):
       ...
     PreconditionError: Didn't meet precondition 'Channels tuned'
@@ -1361,8 +1360,8 @@ def as_precondition(message):
     """
     try:
         yield
-    except UITestFailure as e:
-        debug("stbt.as_precondition caught a UITestFailure exception and will "
+    except TestFailure as e:
+        debug("stbt.as_precondition caught a TestFailure exception and will "
               "re-raise it as PreconditionError.\nOriginal exception was:\n%s"
               % traceback.format_exc(e))
         exc = PreconditionError(message, e)
@@ -1371,23 +1370,27 @@ def as_precondition(message):
         raise exc
 
 
-class UITestError(Exception):
+class TestError(Exception):
     """The test script had an unrecoverable error."""
     pass
 
 
-class UITestFailure(Exception):
+class TestFailure(Exception):
     """The test failed because the system under test didn't behave as expected.
     """
     pass
 
 
-class NoVideo(UITestFailure):
+UITestError = TestError  # For backwards compatibility
+UITestFailure = TestFailure  # For backwards compatibility
+
+
+class NoVideo(TestFailure):
     """No video available from the source pipeline."""
     pass
 
 
-class MatchTimeout(UITestFailure):
+class MatchTimeout(TestFailure):
     """
     * `screenshot`: An OpenCV image from the source video when the search
       for the expected image timed out.
@@ -1405,7 +1408,7 @@ class MatchTimeout(UITestFailure):
             self.expected, self.timeout_secs)
 
 
-class MotionTimeout(UITestFailure):
+class MotionTimeout(TestFailure):
     """
     * `screenshot`: An OpenCV image from the source video when the search
       for motion timed out.
@@ -1424,7 +1427,7 @@ class MotionTimeout(UITestFailure):
             self.timeout_secs)
 
 
-class PreconditionError(UITestError):
+class PreconditionError(TestError):
     """Exception raised by `as_precondition`."""
     def __init__(self, message, original_exception):
         super(PreconditionError, self).__init__()
@@ -1727,7 +1730,7 @@ class Display(object):
                     pipeline, Gst.DebugGraphDetails.ALL, "NoVideo")
             raise NoVideo("No video")
         if isinstance(gst_sample, Exception):
-            raise UITestError(str(gst_sample))
+            raise TestError(str(gst_sample))
 
         return gst_sample
 
@@ -1843,7 +1846,7 @@ class Display(object):
             pipeline, Gst.DebugGraphDetails.ALL, "ERROR")
         err, dbg = message.parse_error()
         self.tell_user_thread(
-            UITestError("%s: %s\n%s\n" % (err, err.message, dbg)))
+            TestError("%s: %s\n%s\n" % (err, err.message, dbg)))
         _mainloop.quit()
 
     def on_warning(self, _bus, message):
@@ -2391,10 +2394,10 @@ def _load_mask(mask):
     mask_path = _find_path(mask)
     debug("Using mask %s" % mask_path)
     if not os.path.isfile(mask_path):
-        raise UITestError("No such mask file: %s" % mask)
+        raise TestError("No such mask file: %s" % mask)
     mask_image = cv2.imread(mask_path, cv2.CV_LOAD_IMAGE_GRAYSCALE)
     if mask_image is None:
-        raise UITestError("Failed to load mask file: %s" % mask_path)
+        raise TestError("Failed to load mask file: %s" % mask_path)
     return mask_image
 
 

--- a/tests/test-stbt-batch.sh
+++ b/tests/test-stbt-batch.sh
@@ -52,7 +52,7 @@ test_that_stbt_batch_run_runs_until_failure() {
     [[ $(cat testruns | wc -l) -eq 2 ]] || fail "Expected 2 test runs"
     first=$(head -1 testruns)
     grep -q success $first/failure-reason || fail "Expected 1st testrun to succeed"
-    grep -q TestError latest/failure-reason || fail "Expected 2nd testrun to fail with 'TestError'"
+    grep -q RuntimeError latest/failure-reason || fail "Expected 2nd testrun to fail with 'RuntimeError'"
     [[ -f $first/thumbnail.jpg ]] || fail "Expected successful testrun to create thumbnail"
     [[ ! -f $first/screenshot.png ]] || fail "Expected successful testrun to not create screenshot"
     [[ -f latest/thumbnail.jpg ]] || fail "Expected failed testrun to create thumbnail"
@@ -68,8 +68,8 @@ test_that_stbt_batch_run_continues_after_uninteresting_failure() {
     [[ $(cat testruns | wc -l) -eq 3 ]] || fail "Expected 3 test runs"
     grep -q success $(head -1 testruns)/failure-reason ||
         fail "Expected 1st testrun to succeed"
-    grep -q TestError $(sed -n 2p testruns)/failure-reason ||
-        fail "Expected 2nd testrun to fail with 'TestError'"
+    grep -q RuntimeError $(sed -n 2p testruns)/failure-reason ||
+        fail "Expected 2nd testrun to fail with 'RuntimeError'"
     grep -q MatchTimeout latest/failure-reason ||
         fail "Expected 3rd testrun to fail with 'MatchTimeout'"
 }
@@ -320,9 +320,9 @@ test_stbt_batch_instaweb() {
     timeout 60 stbt batch run tests/test.py
     [[ $? -eq $timedout ]] && fail "'stbt batch run' timed out"
     rundir=$(ls -d 20* | tail -1)
-    assert grep -q TestError $rundir/failure-reason
-    assert grep -q TestError $rundir/index.html
-    assert grep -q TestError index.html
+    assert grep -q RuntimeError $rundir/failure-reason
+    assert grep -q RuntimeError $rundir/index.html
+    assert grep -q RuntimeError index.html
 
     stbt batch instaweb --debug 127.0.0.1:5787 &
     server=$!
@@ -339,7 +339,7 @@ test_stbt_batch_instaweb() {
     assert grep -q "manual failure reason" index.html
 
     curl --silent --show-error \
-        -F "value=TestError: Not the system-under-test's fault" \
+        -F "value=RuntimeError: Not the system-under-test's fault" \
         http://127.0.0.1:5787/$rundir/failure-reason || fail 'Got HTTP failure'
     expect_runner_to_say "POST /$rundir/failure-reason"
     wait_for_report $server

--- a/tests/test-stbt-batch.sh
+++ b/tests/test-stbt-batch.sh
@@ -52,7 +52,7 @@ test_that_stbt_batch_run_runs_until_failure() {
     [[ $(cat testruns | wc -l) -eq 2 ]] || fail "Expected 2 test runs"
     first=$(head -1 testruns)
     grep -q success $first/failure-reason || fail "Expected 1st testrun to succeed"
-    grep -q UITestError latest/failure-reason || fail "Expected 2nd testrun to fail with 'UITestError'"
+    grep -q TestError latest/failure-reason || fail "Expected 2nd testrun to fail with 'TestError'"
     [[ -f $first/thumbnail.jpg ]] || fail "Expected successful testrun to create thumbnail"
     [[ ! -f $first/screenshot.png ]] || fail "Expected successful testrun to not create screenshot"
     [[ -f latest/thumbnail.jpg ]] || fail "Expected failed testrun to create thumbnail"
@@ -68,8 +68,8 @@ test_that_stbt_batch_run_continues_after_uninteresting_failure() {
     [[ $(cat testruns | wc -l) -eq 3 ]] || fail "Expected 3 test runs"
     grep -q success $(head -1 testruns)/failure-reason ||
         fail "Expected 1st testrun to succeed"
-    grep -q UITestError $(sed -n 2p testruns)/failure-reason ||
-        fail "Expected 2nd testrun to fail with 'UITestError'"
+    grep -q TestError $(sed -n 2p testruns)/failure-reason ||
+        fail "Expected 2nd testrun to fail with 'TestError'"
     grep -q MatchTimeout latest/failure-reason ||
         fail "Expected 3rd testrun to fail with 'MatchTimeout'"
 }
@@ -320,9 +320,9 @@ test_stbt_batch_instaweb() {
     timeout 60 stbt batch run tests/test.py
     [[ $? -eq $timedout ]] && fail "'stbt batch run' timed out"
     rundir=$(ls -d 20* | tail -1)
-    assert grep -q UITestError $rundir/failure-reason
-    assert grep -q UITestError $rundir/index.html
-    assert grep -q UITestError index.html
+    assert grep -q TestError $rundir/failure-reason
+    assert grep -q TestError $rundir/index.html
+    assert grep -q TestError index.html
 
     stbt batch instaweb --debug 127.0.0.1:5787 &
     server=$!
@@ -339,7 +339,7 @@ test_stbt_batch_instaweb() {
     assert grep -q "manual failure reason" index.html
 
     curl --silent --show-error \
-        -F "value=UITestError: Not the system-under-test's fault" \
+        -F "value=TestError: Not the system-under-test's fault" \
         http://127.0.0.1:5787/$rundir/failure-reason || fail 'Got HTTP failure'
     expect_runner_to_say "POST /$rundir/failure-reason"
     wait_for_report $server

--- a/tests/test-stbt-py.sh
+++ b/tests/test-stbt-py.sh
@@ -451,3 +451,30 @@ test_that_transformation_pipeline_transforms_video() {
 	EOF
     ! stbt run -v test.py || fail "Test invalid, shouldn't have matched"
 }
+
+test_backwards_compatibility_with_UITestFailure() {
+    cat > test.py <<-EOF &&
+	import stbt
+	
+	try:
+	    raise stbt.UITestFailure()
+	except stbt.TestFailure:
+	    print "Caught UITestFailure as TestFailure"
+	
+	try:
+	    raise stbt.TestFailure()
+	except stbt.UITestFailure:
+	    print "Caught TestFailure as UITestFailure"
+	
+	try:
+	    raise stbt.MatchTimeout(None, None, None)
+	except stbt.UITestFailure:
+	    print "Caught MatchTimeout as UITestFailure"
+	
+	try:
+	    raise stbt.MatchTimeout(None, None, None)
+	except stbt.TestFailure:
+	    print "Caught MatchTimeout as TestFailure"
+	EOF
+    stbt run -v test.py
+}

--- a/tests/test.py
+++ b/tests/test.py
@@ -11,8 +11,8 @@ for arg in sys.argv[1:]:
 # Fail if this script is run more than once from the same $scratchdir
 n_runs = len(glob.glob("../????-??-??_??.??.??*"))  # includes current run
 if n_runs == 2:
-    raise stbt.UITestError("Not the system-under-test's fault")
-elif n_runs > 2:  # UITestFailure
+    raise stbt.TestError("Not the system-under-test's fault")
+elif n_runs > 2:  # TestFailure
     stbt.wait_for_match("videotestsrc-checkers-8.png", timeout_secs=1)
 
 stbt.press("gamut")

--- a/tests/test.py
+++ b/tests/test.py
@@ -11,7 +11,7 @@ for arg in sys.argv[1:]:
 # Fail if this script is run more than once from the same $scratchdir
 n_runs = len(glob.glob("../????-??-??_??.??.??*"))  # includes current run
 if n_runs == 2:
-    raise stbt.TestError("Not the system-under-test's fault")
+    raise RuntimeError("Not the system-under-test's fault")
 elif n_runs > 2:  # TestFailure
     stbt.wait_for_match("videotestsrc-checkers-8.png", timeout_secs=1)
 

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -1,4 +1,4 @@
 import stbt
 
 if __name__ == '__main__':
-    raise stbt.UITestError("Test Error")
+    raise stbt.TestError("Test Error")

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -1,4 +1,2 @@
-import stbt
-
 if __name__ == '__main__':
-    raise stbt.TestError("Test Error")
+    raise RuntimeError("Test Error")

--- a/tests/test_failure.py
+++ b/tests/test_failure.py
@@ -1,4 +1,4 @@
 import stbt
 
 if __name__ == '__main__':
-    raise stbt.UITestFailure("Test Failure")
+    raise stbt.TestFailure("Test Failure")


### PR DESCRIPTION
The naming of these exceptions always bothered me. What does everyone
think of:

* Renaming `UITestFailure` to `TestFailure` (6cc0730)
* Deprecating `UITestError` (just use `RuntimeError` or whatever
  exception is appropriate) (d15cb36)
