### PR TITLE
stbt.Display: added clock on each frame's left top corner

### DIFF
--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -1789,6 +1789,9 @@ class Display(object):
 
     def draw(self, obj, duration_secs):
         if type(obj) in (str, unicode):
+            obj = (
+                datetime.datetime.now().strftime("%H:%M:%S:%f")[:-4] +
+                ': ' + obj)
             self.text_annotations.append((obj, duration_secs, None))
         elif type(obj) is MatchResult:
             if obj.timestamp is not None:
@@ -1815,6 +1818,9 @@ class Display(object):
                 matches.append(match_result)
             if now >= match_result.timestamp:
                 self.match_annotations.remove(match_result)
+
+        now = datetime.datetime.now().strftime("%H:%M:%S:%f")[:-4]
+        texts = texts + [(now, 0, 0),]
 
         if texts or matches:  # Draw the annotations.
             sample = _gst_sample_make_writable(sample)


### PR DESCRIPTION
While recording a video with this commit there will be visible clock
on left top corner. Clock displays time when given frame was
processed. In addition when calling a function 'press' we will draw not
only an information that button was pressed but as well time when it was
pressed. This should provide accurate information that will let us find
relation between actions registered in logs and what happened on screen.