### PR TITLE
extra/runner/report.py - use SQLite cache of file contents to speed up

### DIFF
--- a/stbt-batch.d/report.py
+++ b/stbt-batch.d/report.py
@@ -6,7 +6,9 @@
 
 """Generates reports from logs of stb-tester test runs created by 'run'."""
 
+import codecs
 import collections
+import contextlib
 from datetime import datetime
 import glob
 import itertools
@@ -14,6 +16,9 @@ import os
 from os.path import abspath, basename, dirname, isdir
 import re
 import sys
+import tempfile
+import shutil
+import sqlite3
 
 import jinja2
 escape = jinja2.Markup.escape
@@ -44,10 +49,12 @@ def main(argv):
 
 
 def index(parentdir):
-    rundirs = [
-        dirname(x) for x in glob.glob(
-            os.path.join(parentdir, "????-??-??_??.??.??*/test-name"))]
-    runs = [Run(d) for d in sorted(rundirs, reverse=True)]
+    with contextlib.closing(FileCache(parentdir)) as cache:
+        rundirs = [
+            dirname(x) for x in glob.glob(
+                os.path.join(parentdir, "????-??-??_??.??.??*/test-name"))]
+        runs = [Run(d, cache) for d in sorted(rundirs, reverse=True)]
+    runs = [run for run in runs if run.failed is False]
     if len(runs) == 0:
         die("Directory '%s' doesn't contain any testruns" % parentdir)
     print templates.get_template("index.html").render(
@@ -64,26 +71,131 @@ def testrun(rundir):
     ).encode('utf-8')
 
 
+class FileCache(collections.MutableMapping):
+    """On file systems that have very high latency file operations or poor
+    performance when attempting to get metadata about a file listing using
+    stat() this cache can help. It behaves like a dictionary; filepaths are
+    keys and the contents of files are values.
+    """
+
+    def __init__(self, parentdir):
+        """Initialize the database. If it doesn't already exist this will result
+        in a new file, 'cache.sqlite', existing in the root of the report
+        directory. It is safe to manually delete this file.
+
+        If we fail to open the database because the remote file system corrupted
+        it or our last transaction was interrupted and it requires a repair then
+        just delete it; it's just a cache and we can start from scratch.
+        """
+        self.source_filepath = os.path.join(parentdir, 'cache.sqlite')
+        if not os.path.isfile(self.source_filepath):
+            with open(self.source_filepath, 'wb') as f_out:
+                pass
+        with contextlib.closing(
+            tempfile.NamedTemporaryFile(delete=False,
+                                        suffix='.cache.sqlite')) as f_out:
+            self.destination_filepath = f_out.name
+        shutil.copy2(self.source_filepath, self.destination_filepath)
+        try:
+            self.connection = sqlite3.connect(self.destination_filepath)
+        except:
+            os.unlink(self.destination_filepath)
+            self.connection = sqlite3.connect(self.destination_filepath)
+        self.connection.row_factory = sqlite3.Row
+        self.cursor = self.connection.cursor()
+        self.cursor.execute("""
+            CREATE TABLE IF NOT EXISTS
+            filecontent(filepath TEXT UNIQUE, contents BLOB)""")
+
+    def close(self):
+        if self.cursor:
+            self.cursor.close()
+            self.cursor = None
+        if self.connection:
+            self.connection.commit()
+            self.connection.close()
+            self.connection = None
+        if os.path.isfile(self.destination_filepath):
+            shutil.copyfile(self.destination_filepath, self.source_filepath)
+            os.unlink(self.destination_filepath)
+
+    def __len__(self):
+        rows = self.cursor.execute("""SELECT COUNT(*)
+                                      FROM filecontent""").fetchall()
+        return rows[0]['COUNT(*)']
+
+    def __iter__(self):
+        for row in self.cursor.execute("""SELECT * FROM filecontent"""):
+            yield row['filepath']
+
+    def __getitem__(self, key):
+        for row in self.cursor.execute("""SELECT * FROM filecontent
+                                          WHERE filepath = ?""", (key, )):
+            return row['contents']
+        raise KeyError
+
+    def __setitem__(self, key, value):
+        self.cursor.execute("""INSERT OR REPLACE INTO filecontent(filepath,
+                                                                  contents)
+                               VALUES (?, ?)""", (key, value))
+        self.connection.commit()
+
+    def __delitem__(self, key):
+        self.cursor.execute("""DELETE FROM filecontent WHERE filepath=?""", key)
+        self.connection.commit()
+
+    def __del__(self):
+        self.close()
+
+
 class Run(object):
-    def __init__(self, rundir):
+    def __init__(self, rundir, cache=None):
+        """Parse information from a stb-tester runner report subdirctory
+        necessary for creating both a test index.html file and for helping
+        create the root summary table of test results.
+
+        Pass in a FileCache object as the cache argument if you wish to use
+        the 'cache.sqlite' file cache in the root of the stb-tester runner
+        report directory to improve performance on slow filesystems. See
+        'FileCache' for more information.
+
+        Note that we obtain a directory listing once, and only once, and avoid
+        all explicit or implicit calls that execute further directory listings.
+        This significantly improves performance on file systems that are not
+        assisted by client or server side caches.
+
+        At this point of execution there is no guarantee that rundir exists.
+        The stb-tester 'instaweb' server can rename directories to prefix
+        a dot in front of them at any time. When processing a large number
+        of test run directories on slow file systems it could be the case
+        the we reach this point and the 'instaweb' server has renamed the
+        directory in the mean time.
+        """
         self.rundir = rundir
 
+        if not os.path.isdir(self.rundir):
+            self.failed = True
+            return
+        self.failed = False
+        self.cache = cache
+
+        dl = set(self._get_directory_listing())
+
         try:
-            self.exit_status = int(self.read("exit-status"))
+            self.exit_status = int(self.read("exit-status", dl))
         except ValueError:
             self.exit_status = "still running"
 
-        self.duration = self.read_seconds("duration")
-        self.failure_reason = self.read("failure-reason")
-        self.git_commit = self.read("git-commit")
-        self.notes = self.read("notes")
-        self.test_args = self.read("test-args")
-        self.test_name = self.read("test-name")
+        self.duration = self.read_seconds("duration", dl)
+        self.failure_reason = self.read("failure-reason", dl)
+        self.git_commit = self.read("git-commit", dl)
+        self.notes = self.read("notes", dl)
+        self.test_args = self.read("test-args", dl)
+        self.test_name = self.read("test-name", dl)
 
         if self.exit_status != "still running":
             self.files = sorted([
-                basename(x) for x in glob.glob(rundir + "/*")
-                if basename(x) not in [
+                x for x in dl if x not in [
                     "duration",
                     "exit-status",
                     "extra-columns",
@@ -94,13 +206,12 @@ class Run(object):
                 ]
                 and not x.endswith(".png")
                 and not x.endswith(".manual")
-                and not basename(x).startswith("index.html")
+                and not x.startswith("index.html")
             ])
-            self.images = sorted([
-                basename(x) for x in glob.glob(rundir + "/*.png")])
+            self.images = sorted([x for x in dl if x.endswith(".png")])
 
         self.extra_columns = collections.OrderedDict()
-        for line in self.read("extra-columns").splitlines():
+        for line in self.read("extra-columns", dl).splitlines():
             column, value = line.split("\t", 1)
             self.extra_columns.setdefault(column.strip(), [])
             self.extra_columns[column.strip()].append(value.strip())
@@ -109,6 +220,9 @@ class Run(object):
             r"\d{4}-\d{2}-\d{2}_\d{2}\.\d{2}\.\d{2}", basename(rundir))
         assert t, "Invalid rundir '%s'" % rundir
         self.timestamp = datetime.strptime(t.group(), "%Y-%m-%d_%H.%M.%S")
+
+    def _get_directory_listing(self):
+        return os.listdir(self.rundir)
 
     def css_class(self):
         if self.exit_status == "still running":
@@ -120,22 +234,35 @@ class Run(object):
         else:
             return "warning"  # Yellow: Test infrastructure error
 
-    def read(self, f):
-        f = os.path.join(self.rundir, f)
-        if os.path.exists(f + ".manual"):
-            return escape(open(f + ".manual").read().decode('utf-8').strip())
-        elif os.path.exists(f):
-            return open(f).read().decode('utf-8').strip()
-        else:
+    def read(self, f, dl):
+        f = self._get_path(f, dl)
+        if f is None:
             return ""
+        if self.cache is not None and f in self.cache:
+            return self.cache[f]
+        with codecs.open(f, encoding='utf-8') as f_in:
+            contents = f_in.read().strip()
+        if f.endswith('.manual'):
+            contents = escape(contents)
+        if self.cache is not None:
+            self.cache[f] = contents
+        return contents
 
-    def read_seconds(self, f):
-        s = self.read(f)
+    def read_seconds(self, f, dl):
+        s = self.read(f, dl)
         try:
             s = int(s)
         except ValueError:
             s = 0
         return "%02d:%02d:%02d" % (s / 3600, (s % 3600) / 60, s % 60)
+
+    def _get_path(self, f, dl):
+        if f + ".manual" in dl:
+            return os.path.join(self.rundir, f + ".manual")
+        elif f in dl:
+            return os.path.join(self.rundir, f)
+        else:
+            return None
 
 
 def die(message):


### PR DESCRIPTION
On file systems where both stat'ing files and getting their contents are
very slow (two or three orders of magnitude slower) this commit improves
performance by five-fold by using an SQLite cache and other changes.

This is a RFC. Although an old version of this code is currently successfully
running on a production system this pull request is of a recently rebased
but untested version.

I would like to break out the `FileCache` object into its own importable file.
This is because on a production system using stb-tester there are other
background processes that are interested in the contents of stb-tester runner
reports but are currently unable to use the existing caches to improve their
read performance. My plan was to break this out into a `FileCache` file and
add respective integration tests to the same file (i.e. tests that go beyond
simple mocking and use an actual directory of files, reads them into the
cache, deletes the actual files, checks the DB still has them, etc.). Thoughts?

I'm concerned that the way in which I've written `_get_path`, by returning
`None`, doesn't really make sense, however it did help me make the `read`
code more concise. Suggestions as to how to express the logic here are welcome.