### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:14.04
+MAINTAINER will@stb-tester.com
+
+ENV DEBIAN_FRONTEND noninteractive
+
+ADD extra/debian/control /tmp/runtime-deps
+RUN apt-get update && \
+    apt-get dist-upgrade -y && \
+    apt-get install -y $(awk '/^         [^$ ]/ {print $1}' /tmp/runtime-deps | sed 's/,//g') && \
+    apt-get clean && \
+    rm /tmp/runtime-deps
+
+ADD . /tmp/source
+RUN apt-get install -y git make python-docutils && \
+    make -C /tmp/source prefix=/usr sysconfdir=/etc libexecdir=/usr/lib install && \
+    rm -Rf /tmp/source && \
+    apt-get remove -y --purge git make python-docutils && \
+    apt-get -y --purge autoremove && \
+    apt-get clean
+
+RUN adduser --home /var/lib/stbt --uid 1000 stb-tester && \
+    echo "stb-tester    ALL=(ALL:ALL) NOPASSWD:ALL" >/etc/sudoers.d/stb-tester
+    
+USER stb-tester
+
+RUN mkdir -p /var/lib/stbt/results /var/lib/stbt/tests
+
+VOLUME ["/var/lib/stbt/results"]
+
+ENTRYPOINT ["/usr/bin/stbt"]

--- a/Makefile
+++ b/Makefile
@@ -314,8 +314,17 @@ copr-publish: $(src_rpm)
 	copr-cli build stb-tester \
 	    https://github.com/drothlis/stb-tester-srpms/raw/master/$(src_rpm)
 
+# Docker images
 
-.PHONY: all clean check deb dist doc install uninstall
+docker-build : stb-tester-$(VERSION).tar.gz
+	tmpdir=$$(mktemp -d) && \
+	tar -C "$$tmpdir" -xzf $(abspath $<) && \
+	find "$$tmpdir/stb-tester-$(VERSION)" -print0 | xargs -0 touch -cht 197001010000.00 && \
+	docker.io build --rm=false -t stb-tester:$(VERSION) "$$tmpdir/stb-tester-$(VERSION)" && \
+	rm -rf "$$tmpdir" && \
+	printf "Run with:\n    docker.io run stb-tester:$(VERSION)\n"
+
+.PHONY: all clean check deb dist doc docker-build install uninstall
 .PHONY: check-bashcompletion check-hardware check-integrationtests
 .PHONY: check-nosetests check-pylint install-for-test
 .PHONY: copr-publish ppa-publish srpm


### PR DESCRIPTION
[Docker] is a implementation of Linux containers which offer many of the
same benefits as virtual machines, but are much more lightweight.  They
allow you to package up a program and it's dependencies such that it will
run exactly the same on any machine.  They can also provide isolatoion such
that the host machine is isolated from changes made in the container.

This is potentially very useful to stb-tester.  stb-tester can be difficult
to deploy due to the dependencies.  Docker offers a way to easily provide a
standardised stb-tester environment.  It is also useful in a CI context as,
much like Travis, you could run arbritary user code without risking the
host system.

A Dockerfile contains the instructions on how to create a container.
Containers start out with a base image and build on top of that.  In this
case the stb-tester container is based ubuntu 14.04 (LTS).  Any container
can be used as the base for other containers.  Our users can base their
containers on the stb-tester container if they wish.

Docker also provides an [index].  This is a global repository of docker
images.  Docker containers in the index are easier to deploy[^1] and use as
a base for other images.  It also provides a service called "[trusted
builds]" where your image will be built and published for you, from github,
with a guarantee that the sources there are the source of the container.
One constraint is that the Dockerfile must be in the root of the repo and
present at clone time.  This means that we can't generate it as a part of
the build process.

[^1]: You can just type `docker run stb-tester:latest` and you're up and
      running.
[Docker]: http://docker.io/
[index]: https://index.docker.io/
[trusted builds]: http://blog.docker.com/2013/11/introducing-trusted-builds/