### PR TITLE
stbt batch: New hooks for custom test report and summary generators

### DIFF
--- a/stbt-batch.d/README.rst
+++ b/stbt-batch.d/README.rst
@@ -41,10 +41,10 @@ User hooks
 ----------
 
 The following hooks are available for custom log collection, failure
-classification, and failure recovery. Each hook is a variable in the stbt
-configuration file; if the variable is set to an executable program, ``run``
-will invoke that program at the appropriate time, with the current working
-directory set to the directory containing the test run logs:
+classification, failure recovery, and custom report generation. Each hook is a
+variable in the stbt configuration file; if the variable is set to an executable
+program, ``run`` will invoke that program at the appropriate time, with the
+current working directory set to the directory containing the test run logs:
 
 **batch.pre_run**
   Invoked immediately before the test is run, with the
@@ -109,6 +109,48 @@ directory set to the directory containing the test run logs:
   followed by a tab, followed by a value (arbitrary text). Multiple lines with
   the same key will have their values merged into a single column. The program
   should append to the ``extra-columns`` file, not overwrite it.
+
+**batch.report**
+  Invoked twice per test run by ``stbt batch run``: first very early before the
+  test is started and before any other hook; next after the test and all other
+  hooks have completed. Also invoked when ``stbt batch report`` is run by the
+  user, once in each directory specified in the command line arguments.
+
+  Intended for generating a custom-tailored test report. It may be used to
+  update the database of some other test reporting system. Replaces the built-in
+  html test report generator.
+
+  During the first invocation it can read ``test-name`` file and its purpose is
+  to indicate that the test is currently being executed; ``failure-reason`` and
+  ``exit-status`` are not available in that phase. During the second invocation,
+  after the test has completed, it has access to all files that
+  ``batch.classify`` does.
+
+  Using a custom ``report`` generator with the built-in ``summary`` generator
+  requires each ``report`` execution to generate an ``index.html`` file in
+  the current working directory.
+
+**batch.summary**
+  Invoked by ``stbt batch run`` right after a ``report`` hook, with the
+  difference that its current working directory is the current batch run's root
+  directory. When ``stbt batch report`` is run by the user, it is invoked in
+  the specified test run directories' parent directory, after all ``report``
+  executions have completed.
+
+  Intended for publishing a summary report, updated with the status of the
+  latest ongoing or completed testrun. Replaces the built-in html summary
+  generator.
+
+  It has access to all test runs of a batch execution in the following
+  structure::
+
+      batch_run_root  # The current working directory
+      |-- testrun1
+      |   `-- logs
+      |-- testrun2
+      |   `-- logs
+      |-- current  # Symlink to the currently executed test's directory
+      `-- latest  # Symlink to the most recently completed test's directory
 
 instaweb
 --------

--- a/stbt-batch.d/report
+++ b/stbt-batch.d/report
@@ -50,8 +50,12 @@ main() {
           echo "$rundir: Not a test result directory; skipping"
           return 0
         }
-        python "$runner"/report.py . > index.html.$$ &&
-        mv index.html.$$ index.html
+        if "$runner"/../stbt-config batch.report 2>/dev/null; then
+          user_command report
+        else
+          python "$runner"/report.py . > index.html.$$ &&
+          mv index.html.$$ index.html
+        fi
       fi
     ) || return
   done
@@ -63,8 +67,12 @@ main() {
     do
       (
         cd "$resultsdir" || die "Invalid directory '$resultsdir'"
-        python "$runner"/report.py index.html > index.html.$$ &&
-        mv index.html.$$ index.html
+        if "$runner"/../stbt-config batch.summary 2>/dev/null; then
+          user_command summary
+        else
+          python "$runner"/report.py index.html > index.html.$$ &&
+          mv index.html.$$ index.html
+        fi
       )
     done
   fi


### PR DESCRIPTION
`report.py` has certain limitations: generating static pages and not
using a database back-end makes it somewhat unsuitable for reporting
large volumes of test results; it doesn't allow sending stb-tester
results to an external reporting system.

To allow `stbt batch` users to overcome the above issues, add two new
user hooks, `batch.report` and `batch.summary` that may replace some or
all of `report.py` functionality with user programs.

The idea to replace `report.py` is the result of the following
considerations:
- Forking and building stb-tester with a customised `stbt batch` would
  involve the maintenance burden of continuously backporting changes
  from upstream. We'd prefer to use official releases.
- Implementing a custom test runner instead of using `stbt batch` is
  certainly viable, but replacing just the report generator saves the
  hassle of reimplementing a very similar test runner.
- Replacing `stbt batch report` would be ambiguous, because this is the
  script that and invokes the `classify` hook. Also, it generates
  `failure-reason`, which is actually very useful.

`report.py` has two different functionalities:
- `report.py <testrun-dir>` generates a test report of a single test
  run,
- `report.py index.html` generates a summary report of all test runs.
The former may be replaced with `batch.report` and the latter with
`batch.summary` user programs, using single-word hook names for
simplicity. Specifying `batch.report` or `batch.summary` with no
value skips test report or summary generation respectively.

A possible use case is generating dynamic report pages. The `report`
hook fills a database using the contents of files provided by `stbt
batch run`. The `summary` hook is skipped, or it may e.g. send e-mail
notifications if the ratio of failed tests exceeds a threshold.

See the additions to README.rst for further details.