### PR TITLE
Fixes for issues with restarting the device under test

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -143,6 +143,8 @@ Additional options to stbt run
 
 --save-video=<file>
   Record a video (in the HTML5-compatible WebM format) to the specified `file`.
+  Multiple video files are created in case of video loss from VidiU or HD PVR
+  video-capture devices, indexed as `file`, `file1`, `file2` etc.
 
 Additional options to stbt record
 ---------------------------------

--- a/README.rst
+++ b/README.rst
@@ -143,8 +143,6 @@ Additional options to stbt run
 
 --save-video=<file>
   Record a video (in the HTML5-compatible WebM format) to the specified `file`.
-  Multiple video files are created in case of video loss from VidiU or HD PVR
-  video-capture devices, indexed as `file`, `file1`, `file2` etc.
 
 Additional options to stbt record
 ---------------------------------

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -1780,6 +1780,7 @@ class Display(object):
     def restart_source(self):
         warn("Attempting to recover from video loss: "
              "Stopping source pipeline and waiting 5s...")
+        self.sink_pipeline.set_state(Gst.State.NULL)
         self.source_pipeline.set_state(Gst.State.NULL)
         self.source_pipeline = None
         GObjectTimeout(5, self.start_source).start()
@@ -1791,6 +1792,7 @@ class Display(object):
         warn("Restarting source pipeline...")
         self.create_source_pipeline()
         self.source_pipeline.set_state(Gst.State.PLAYING)
+        self.sink_pipeline.set_state(Gst.State.PLAYING)
         warn("Restarted source pipeline")
         if self.restart_source_enabled:
             self.underrun_timeout.start()

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -1547,14 +1547,17 @@ class Display(object):
             appsink])
         self.create_source_pipeline()
 
-        if save_video:
-            if not save_video.endswith(".webm"):
-                save_video += ".webm"
-            debug("Saving video to '%s'" % save_video)
+        self.video_file_name = save_video
+        self.video_file_index = 0
+        if self.video_file_name:
+            if not self.video_file_name.endswith(".webm"):
+                self.video_file_name += ".webm"
+            debug("Saving video to '%s'" % self.video_file_name)
             video_pipeline = (
                 "t. ! queue leaky=downstream ! videoconvert ! "
                 "vp8enc cpu-used=6 min_quantizer=32 max_quantizer=32 ! "
-                "webmmux ! filesink location=%s" % save_video)
+                "webmmux ! filesink name=_stbt_filesink location=%s"
+                % self.video_file_name)
         else:
             video_pipeline = ""
 
@@ -1800,12 +1803,21 @@ class Display(object):
         self.timestamp_offset = \
             self.last_timestamp + (time.time() - self.last_sample_time) * 1e9
         ddebug("start_source: new timestamp offset: %d" % self.timestamp_offset)
+        self.start_new_video_file()
         self.source_pipeline.set_state(Gst.State.PLAYING)
         self.sink_pipeline.set_state(Gst.State.PLAYING)
         warn("Restarted source pipeline")
         if self.restart_source_enabled:
             self.underrun_timeout.start()
         return False  # stop the timeout from running again
+
+    def start_new_video_file(self):
+        filesink = self.sink_pipeline.get_by_name("_stbt_filesink")
+        if filesink:
+            self.video_file_index += 1
+            base, ext = os.path.splitext(self.video_file_name)
+            filesink.set_property(
+                "location", "%s%d%s" % (base, self.video_file_index, ext))
 
     @staticmethod
     def appsink_await_eos(appsink, timeout=None):

--- a/tests/test-stbt-py.sh
+++ b/tests/test-stbt-py.sh
@@ -408,3 +408,13 @@ test_that_transformation_pipeline_transforms_video() {
 	EOF
     ! stbt run -v test.py || fail "Test invalid, shouldn't have matched"
 }
+
+test_that_restart_source_doesnt_increase_timeout() {
+    cat > test.py <<-EOF &&
+	import stbt
+	for i, _ in enumerate(stbt.frames(timeout_secs=10)):
+	    if i == 75:  # ~3 secs
+	        stbt._display.restart_source()
+	EOF
+    timeout 11s stbt run -v test.py || fail "Exceeded the expected timeout"
+}


### PR DESCRIPTION
A number of fixes for issues that occur when the video stream is restarted or the video resulution changes during a set-top-box restart.

I've validated the fixes by running 2000 iterations of a test that reboots the set-top-box, but more thorough testing with various test scripts is still in progress.

The first three commits address three individual issues.

The last two commits are alternative solutions for a side-effect of "Stop sink pipeline while the source pipeline is restarting" and I'm not happy with either one; I would be glad if you could propose a better one.

--

The different issues addressed in this pull request:

1. **Drop the last sample on underrun**

    > `stbt._display.last_sample` stores the most recent GSt buffer until
    > `stbt.gst_samples` removes it or it's replaced by a newer buffer.
    > To put it other way, if the video stream stops then `gst_samples`
    > yields the very last sample of the video stream even though it's called
    > minutes later.

2. **"Not negotiated" error when restarting source pipeline after VidiU
   EOS, if using `--save-video`**

    This is issue #211.

3. **Timestamps restart from 0 after a source pipeline restart**

    This makes `timeout_secs` unpredictable, and it corrupts the saved video.

4. **Video isn't streamable**

    Though this has a separate fix in the pull request, hopefully it will be
    fixed by a proper solution to issue 2 above.
