### PR TITLE
stbt batch run: Fix `UnicodeEncodeError` when printing Unicode strings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ install:
  - sudo apt-get update
  - sudo apt-get install
         expect
+        expect-dev
         gir1.2-gstreamer-1.0
         gir1.2-gudev-1.0
         gstreamer1.0-libav

--- a/_stbt/logging.py
+++ b/_stbt/logging.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 
 import argparse
-import codecs
 import os
 import sys
 from contextlib import contextmanager
@@ -9,24 +8,23 @@ from contextlib import contextmanager
 from .config import get_config
 
 _debug_level = None
-_debugstream = codecs.getwriter('utf-8')(sys.stderr)
 
 
 def debug(msg):
     """Print the given string to stderr if stbt run `--verbose` was given."""
     if get_debug_level() > 0:
-        _debugstream.write(
+        sys.stderr.write(
             "%s: %s\n" % (os.path.basename(sys.argv[0]), msg))
 
 
 def ddebug(s):
     """Extra verbose debug for stbt developers, not end users"""
     if get_debug_level() > 1:
-        _debugstream.write("%s: %s\n" % (os.path.basename(sys.argv[0]), s))
+        sys.stderr.write("%s: %s\n" % (os.path.basename(sys.argv[0]), s))
 
 
 def warn(s):
-    _debugstream.write("%s: warning: %s\n" % (
+    sys.stderr.write("%s: warning: %s\n" % (
         os.path.basename(sys.argv[0]), s))
 
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -20,6 +20,15 @@ For installation instructions see
 
 ##### Breaking changes since 0.21
 
+* stbt run will now set the encoding of stderr and stdout to utf-8 when writing
+  to a file or pipe (or otherwise not connected to a terminal with `LANG` set)
+  rather than defaulting back to ASCII.  This makes the behaviour more
+  consistent between using `stbt run` (interactively) and `stbt batch run` which
+  logs to a file.  Previously a `UnicodeEncodeError` would be `raise`d when
+  `print`ing a unicode string like `print u"Alfonso Cuarón"`.
+
+  This is the same (sensible) behaviour that Python 3 has by default.
+
 ##### User-visible changes since 0.21
 
 * API: `is_frame_black()` now no longer requires a frame to be passed in.  If

--- a/stbt-run
+++ b/stbt-run
@@ -30,6 +30,20 @@ sys.argv[1:] = args.args
 stbt.debug("Arguments:\n" + "\n".join([
     "%s: %s" % (k, v) for k, v in args.__dict__.items()]))
 
+
+def _setup_utf8_output():
+    """
+    Simulates python3's defaulting to utf-8 output so we don't get confusing
+    `UnicodeEncodeError`s when printing unicode characters.
+    """
+    import codecs
+    if sys.stdout.encoding is None:
+        sys.stdout = codecs.getwriter('utf8')(sys.stdout)
+    if sys.stderr.encoding is None:
+        sys.stderr = codecs.getwriter('utf8')(sys.stderr)
+
+_setup_utf8_output()
+
 try:
     stbt.init_run(
         args.source_pipeline, args.sink_pipeline, args.control,

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -1,9 +1,7 @@
 # coding: utf-8
 
-import codecs
 import distutils
 import re
-import sys
 from textwrap import dedent
 
 import cv2
@@ -11,8 +9,6 @@ from nose.plugins.skip import SkipTest
 from nose.tools import eq_, raises
 
 import stbt
-
-sys.stdout = codecs.getwriter('utf8')(sys.stdout)
 
 
 def test_that_ocr_returns_unicode():


### PR DESCRIPTION
When stbt is outputting to a terminal it will choose the encoding of the
stdout and stderr streams based on the LOCALE in use.  When it doesn't
detect a TTY attached to stdout/stderr it will default to ASCII output.

`stbt run` outputs directly to the terminal.  `stbt batch run` redirects
the output of `stbt run` to `tee` and then to a log file.

This means that if you `print u"Alfonso Cuarón"` in a test script (or
more likely `print` the output of `stbt.ocr`) whether you get a
`UnicodeEncodeError` will depend on whether you are using `stbt run` or
`stbt batch run`.

Python 3 fixes this issue by falling back to encoding as utf-8 rather than
ASCII.

This is technically a backwards-incompatible change but I don't expect that
it will break any test-scripts in the wild.  In fact I think the opposite
will be true.  You could however make the argument that it would be better
to stick to Python 2, warts and all or make the jump to Python 3 proper
rather than creating this weird middle-ground.  This would be a stronger
argument if `stbt` were a normal Python library which people were using in
web-servers and text-processing where complete understanding and control
over encoding is necessary, but for stb test scripts I think the path of
least-surprise is setting the encoding as in this patch.