### PR TITLE
API: `is_screen_black`: Make `frame` parameter optional

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -418,12 +418,13 @@ get_config(section, key, default=None, type_=<type 'str'>)
 get_frame()
     Returns an OpenCV image of the current video frame.
 
-is_screen_black(frame, mask=None, threshold=None)
+is_screen_black(frame=None, mask=None, threshold=None)
     Check for the presence of a black screen in a video frame.
 
     `frame` (numpy.array)
-      The video frame to check, in OpenCV format (for example as returned by
-      `frames` and `get_frame`).
+      If this is specified it is used as the video frame to check; otherwise a
+      frame is grabbed from the source video stream. It is a `numpy.array` in
+      OpenCV format (for example as returned by `frames` and `get_frame`).
 
     `mask` (string)
       The filename of a black & white image mask. It must have white pixels for

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -22,6 +22,9 @@ For installation instructions see
 
 ##### User-visible changes since 0.21
 
+* API: `is_frame_black()` now no longer requires a frame to be passed in.  If
+  one is not specified it will be grabbed from live video, much like `match()`.
+
 ##### Bugfixes and packaging fixes since 0.21
 
 ##### Developer-visible changes since 0.21


### PR DESCRIPTION
This makes it consistent with the other functions such as `match()`, and makes it more useful with a hypothetical `wait_until`, allowing constructions such as:

    assert wait_until(is_screen_black)