### PR TITLE
stbt.py: Modified as_precondition to include original traceback

### DIFF
--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -21,6 +21,7 @@ import re
 import subprocess
 import threading
 import time
+import traceback
 import warnings
 from collections import deque, namedtuple
 from contextlib import contextmanager
@@ -1357,6 +1358,9 @@ def as_precondition(message):
     try:
         yield
     except UITestFailure as e:
+        debug("stbt.as_precondition caught a UITestFailure exception and will "
+              "re-raise it as PreconditionError.\nOriginal exception was:\n%s"
+              % traceback.format_exc(e))
         exc = PreconditionError(message, e)
         if hasattr(e, 'screenshot'):
             exc.screenshot = e.screenshot  # pylint: disable=W0201


### PR DESCRIPTION
Within the as_precondition context manager, whenever a UITestFailure
is raised, log the original exception's traceback with stbt.debug.

This makes it easier to determine exactly where and why a precondition
has failed, as the PreconditionError that is raised within as_precondition
only shows the message of the original exception, not the traceback.