### PR TITLE
stbt-run: Allow running tests by test name

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -138,16 +138,19 @@ Edit the test script to:
 
     import stbt
 
-    stbt.press('gamut')
-    stbt.wait_for_match('0000-gamut-complete.png')
-    stbt.press('checkers-8')
-    stbt.wait_for_match('0001-checkers-8-complete.png')
-    stbt.press('snow')
-    stbt.wait_for_motion()
+    def test_that_the_video_pattern_changes():
+        stbt.press('gamut')
+        stbt.wait_for_match('0000-gamut-complete.png')
+        stbt.press('checkers-8')
+        stbt.wait_for_match('0001-checkers-8-complete.png')
+        stbt.press('snow')
+        stbt.wait_for_motion()
 
 The test script is written in the Python programming language. You can use any
 Python feature, including Python's standard libraries; you can also use
 third-party Python libraries if you have them installed on your system.
+
+Each test case is a Python function that starts with **test_**.
 
 **stbt.press** takes a string that must be understood by the control specified
 in the configuration file.
@@ -176,7 +179,7 @@ Run `stbt screenshot --help` for details.
 
 Now use **stbt run** to try the test script we just recorded:
 
-    stbt run --verbose test.py
+    stbt run --verbose test.py::test_that_the_video_pattern_changes
 
 Check *stbt*'s exit status (type `echo $?`) for success or failure. Read our
 [Unix Shell tutorial] if you aren't familiar with process exit statuses on
@@ -190,7 +193,7 @@ is stb-tester's bulk test-runner and reporting system:
 
     mkdir results  # Make a directory where you want to store the test results
     cd results
-    stbt batch run /path/to/test.py  # Give the actual path to the test script
+    stbt batch run /path/to/test.py::test_that_the_video_pattern_changes
 
 After the test has run a few times, press Control-C to stop it. Now open
 *index.html* in your web browser. You should see a report somewhat like this:

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -36,6 +36,46 @@ For installation instructions see
 
 ##### User-visible changes since 0.21
 
+* `stbt run` and `stbt batch run` can now run a specific Python function in the
+  test file if you give the testcase name as
+  `test_file_name.py::test_function_name`.
+
+  For example, if you have a file `test.py` that looks like this:
+
+        import stbt
+
+        def test_that_logo_is_shown():
+            stbt.wait_for_match("logo.png")
+
+        def test_that_menu_appears():
+            stbt.press("KEY_MENU")
+            stbt.wait_for_match("menu.png")
+
+  ...then you can run one of the tests like this:
+
+        stbt run test.py::test_that_logo_is_shown
+
+  This has several advantages over the existing one-test-per-file approach:
+
+    * It encourages smaller, more descriptive testcases.
+    * It makes it easier to factor out and share common code between testcases.
+    * You can attach documentation or metadata to testcases (using docstrings,
+      `nose.plugins.attrib.attr`, etc.) which can be queried by importing the
+      test file and inspecting the functions.
+    * It is the same approach used by [nose] and [pytest] which opens doors in
+      the future to make use of facilities that these test frameworks provide.
+      See [our blog post](
+      http://stb-tester.com/blog/2014/09/25/upcoming-features-new-test-runner.html)
+      for some possible future directions.
+
+  This is the format we recommend going forward (of course the old format is
+  still supported). We have used this format exclusively for 6+ months in a
+  client's project and it works well. The *stb-tester <small>ONE</small>*
+  appliance will require this format.
+
+  We recommend that you name your testcase functions to start with "test_", for
+  future compatibility with test frameworks like [nose] and [pytest].
+
 * API: New function `wait_until` runs any given function or lambda expression
   until it succeeds, or until a timeout. This provides the waiting behaviour of
   `wait_for_match`, but more general -- you can use it to look for a match or
@@ -45,6 +85,9 @@ For installation instructions see
 
 * API: `is_frame_black()` now no longer requires a frame to be passed in.  If
   one is not specified it will be grabbed from live video, much like `match()`.
+
+[nose]: https://nose.readthedocs.org/
+[pytest]: http://pytest.org/latest/
 
 ##### Bugfixes and packaging fixes since 0.21
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -34,6 +34,10 @@ For installation instructions see
   `wait_until` in this release, this provides a more composable API. See the
   documentation for `wait_until` for more details.
 
+* `stbt record` now creates python files with the testcase in a Python function
+  instead of at the top level of the file. See the change to `stbt run` in the
+  next section for more details.
+
 ##### User-visible changes since 0.21
 
 * `stbt run` and `stbt batch run` can now run a specific Python function in the

--- a/stbt-record
+++ b/stbt-record
@@ -51,10 +51,11 @@ def record(control_recorder, script_out):
     count = itertools.count()
     old_key = None
     script_out.write("import stbt\n\n\n")
+    script_out.write("def test_that_WRITE_TESTCASE_DESCRIPTION_HERE():\n")
     try:
         for key in stbt.control.uri_to_remote_recorder(control_recorder):
             write_wait_for_match(script_out, count.next(), old_key)
-            script_out.write("stbt.press('%s')\n" % key)
+            script_out.write("    stbt.press('%s')\n" % key)
             stbt.press(key)
             old_key = key
     except KeyboardInterrupt:
@@ -68,7 +69,7 @@ def write_wait_for_match(script_out, i, old_key):
         return
     filename = "%04d-%s-complete.png" % (i, old_key)
     stbt.save_frame(stbt.get_frame(), filename)
-    script_out.write("stbt.wait_for_match('%s')\n" % filename)
+    script_out.write("    stbt.wait_for_match('%s')\n" % filename)
 
 
 if __name__ == "__main__":

--- a/stbt-run
+++ b/stbt-run
@@ -44,23 +44,43 @@ def _setup_utf8_output():
 
 _setup_utf8_output()
 
+
+def import_by_filename(filename_):
+    module_dir, module_file = os.path.split(filename_)
+    module_name, module_ext = os.path.splitext(module_file)
+    if module_ext != '.py':
+        raise ImportError("Invalid module filename '%s'" % filename_)
+    sys.path = [os.path.abspath(module_dir)] + sys.path
+    try:
+        return __import__(module_name)
+    finally:
+        sys.path = sys.path[1:]
+
 try:
+    # pylint: disable=W0611
+
     stbt.init_run(
         args.source_pipeline, args.sink_pipeline, args.control,
         args.save_video, args.restart_source,
         stbt.get_config('global', 'transformation_pipeline'))
-    # pylint: disable=W0611
-    from stbt import (
-        # For backwards compatibility. We want to encourage people to
-        # explicitly import stbt in their scripts, so don't add new APIs here.
-        press, press_until_match, wait_for_match, wait_for_motion,
-        detect_match, MatchResult, Position, detect_motion, MotionResult,
-        save_frame, get_frame, MatchParameters,
-        debug, UITestError, UITestFailure, MatchTimeout, MotionTimeout,
-        ConfigurationError)
-    __file__ = args.script
-    sys.path.insert(0, os.path.dirname(os.path.abspath(args.script)))
-    execfile(args.script)
+
+    if '::' in args.script:
+        filename, function = args.script.split('::', 1)
+        module = import_by_filename(filename)
+        function = getattr(module, function)
+        function()
+    else:
+        from stbt import (
+            # For backwards compatibility. We want to encourage people to expli-
+            # citly import stbt in their scripts, so don't add new APIs here.
+            press, press_until_match, wait_for_match, wait_for_motion,
+            detect_match, MatchResult, Position, detect_motion, MotionResult,
+            save_frame, get_frame, MatchParameters,
+            debug, UITestError, UITestFailure, MatchTimeout, MotionTimeout,
+            ConfigurationError)
+        __file__ = args.script
+        sys.path.insert(0, os.path.dirname(os.path.abspath(args.script)))
+        execfile(args.script)
 except Exception as e:  # pylint: disable=W0703
     sys.stdout.write("FAIL: %s: %s: %s\n" % (args.script, type(e).__name__, e))
     if hasattr(e, "screenshot") and e.screenshot is not None:

--- a/tests/test-stbt-batch.sh
+++ b/tests/test-stbt-batch.sh
@@ -7,7 +7,7 @@ create_test_repo() {
         cd tests &&
         git config user.name "Stb Tester" &&
         git config user.email "test-stbt-batch@stb-tester.com" &&
-        cp "$testdir/test.py" "$testdir/test2.py" \
+        cp "$testdir/test.py" "$testdir/test2.py" "$testdir/test_functions.py" \
            "$testdir"/test_{success,error,failure}.py \
            "$testdir/videotestsrc-checkers-8.png" \
            "$testdir/videotestsrc-gamut.png" . &&
@@ -41,6 +41,14 @@ test_stbt_batch_run_once() {
     grep -q "$expected_commit" index.html || fail "git commit not in index.html"
     grep -q "my label" latest/index.html || fail "extra column not in latest/index.html"
     grep -q "my label" index.html || fail "extra column not in index.html"
+}
+
+test_that_stbt_batch_run_will_run_a_specific_function() {
+    create_test_repo
+    stbt batch run -o results -1 \
+        tests/test_functions.py::test_that_this_test_is_run \
+    || fail "Test failed"
+    [ -e "results/current/touched" ] || fail "Test not run"
 }
 
 test_that_stbt_batch_run_runs_until_failure() {

--- a/tests/test-stbt-control.sh
+++ b/tests/test-stbt-control.sh
@@ -29,12 +29,13 @@ validate_stbt_record_control_recorder() {
 	import stbt
 	
 	
-	stbt.press('gamut')
-	stbt.wait_for_match('0001-gamut-complete.png')
-	stbt.press('checkers-8')
-	stbt.wait_for_match('0002-checkers-8-complete.png')
-	stbt.press('smpte')
-	stbt.wait_for_match('0003-smpte-complete.png')
+	def test_that_WRITE_TESTCASE_DESCRIPTION_HERE():
+	    stbt.press('gamut')
+	    stbt.wait_for_match('0001-gamut-complete.png')
+	    stbt.press('checkers-8')
+	    stbt.wait_for_match('0002-checkers-8-complete.png')
+	    stbt.press('smpte')
+	    stbt.wait_for_match('0003-smpte-complete.png')
 	EOF
     diff -u expected test.py
 }

--- a/tests/test-stbt-record.sh
+++ b/tests/test-stbt-record.sh
@@ -5,6 +5,18 @@ test_record() {
         sleep 1; echo gamut;
         sleep 1; echo checkers-8;
         sleep 1; echo smpte; sleep 1;) &&
+    diff -u - test.py <<-EOF &&
+	import stbt
+	
+	
+	def test_that_WRITE_TESTCASE_DESCRIPTION_HERE():
+	    stbt.press('gamut')
+	    stbt.wait_for_match('0001-gamut-complete.png')
+	    stbt.press('checkers-8')
+	    stbt.wait_for_match('0002-checkers-8-complete.png')
+	    stbt.press('smpte')
+	    stbt.wait_for_match('0003-smpte-complete.png')
+	EOF
     [ -f 0001-gamut-complete.png ] &&
     [ -f 0002-checkers-8-complete.png ] &&
     [ -f 0003-smpte-complete.png ] &&

--- a/tests/test-stbt-run.sh
+++ b/tests/test-stbt-run.sh
@@ -118,3 +118,13 @@ test_that_stbt_run_exits_on_ctrl_c() {
         *) fail "Unexpected return code $exit_status";;
     esac
 }
+
+test_that_stbt_run_will_run_a_specific_function() {
+    cat > test.py <<-EOF
+	import stbt
+	def test_that_this_test_is_run():
+	    open("touched", "w").close()
+	EOF
+    stbt run test.py::test_that_this_test_is_run
+    [ -e "touched" ] || fail "Test not run"
+}

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,0 +1,2 @@
+def test_that_this_test_is_run():
+    open("touched", "w").close()


### PR DESCRIPTION
You can now run a test with:

     stbt run test.py::my_test_function_name

This mimics py.test's command line interface, except that `stbt run test.py` won't run all `test_*` functions in the file.

This brings `stbt` to parity with the stb-tester ᴏɴᴇ appliance.

TODO:

* [x] Decide whether we should scrap this and figure out how to get py.test to create `stbt batch`-style reports, or whether we need to support this in `stbt run` as an interim measure.
* [x] Selftest that `stbt batch` works with this style of test name.
* [x] Release notes.
* [x] Review release notes wording.
* [x] Update stbt record to create a script in this style.
* [x] Update `docs/getting-started.md` etc.
* ~~Update tab-completion script for `stbt run` and `stbt batch run`.~~