### PR TITLE
stbt run: Treat AssertionErrors as test failures, not test errors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -211,9 +211,10 @@ EXIT STATUS
 
 Test scripts indicate **failure** (the system under test didn't behave as
 expected) by raising an instance of `stbt.UITestFailure` (or a subclass
-thereof). Any other exception is considered a test **error** (a logic error in
-the test script, an error in the system under test's environment, or an error
-in the test framework itself).
+thereof) or `AssertionError` (which is raised by Python's `assert` statement).
+Any other exception is considered a test **error** (a logic error in the test
+script, an error in the system under test's environment, or an error in the
+test framework itself).
 
 
 HARDWARE REQUIREMENTS
@@ -317,16 +318,17 @@ The following functions are available:
 .. <start python docs>
 
 as_precondition(message)
-    Context manager that replaces UITestFailures with UITestErrors.
+    Context manager that replaces test failures with test errors.
 
     If you run your test scripts with stb-tester's batch runner, the reports it
-    generates will show test failures (that is, `UITestFailure` exceptions) as
-    red results, and unhandled exceptions of any other type as yellow results.
-    Note that `wait_for_match`, `wait_for_motion`, and similar functions raise
-    `UITestFailure` (red results) when they detect a failure. By running such
-    functions inside an `as_precondition` context, any `UITestFailure` (red)
-    they raise will be caught, and a `UITestError` (yellow) will be raised
-    instead.
+    generates will show test failures (that is, `stbt.UITestFailure` or
+    `AssertionError` exceptions) as red results, and test errors (that is,
+    unhandled exceptions of any other type) as yellow results. Note that
+    `wait_for_match`, `wait_for_motion`, and similar functions raise a
+    `stbt.UITestFailure` when they detect a failure. By running such functions
+    inside an `as_precondition` context, any `stbt.UITestFailure` or
+    `AssertionError` exceptions they raise will be caught, and a
+    `stbt.PreconditionError` will be raised instead.
 
     When running a single test script hundreds or thousands of times to
     reproduce an intermittent defect, it is helpful to mark unrelated failures

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -29,6 +29,30 @@ For installation instructions see
 
   This is the same (sensible) behaviour that Python 3 has by default.
 
+* `stbt run` and `stbt batch run` treat `AssertionError`s as test failures, not
+  test errors. Along with the introduction of `match` in stb-tester 0.21 and
+  `wait_until` in this release, (TODO: MAKE SURE THIS HAPPENS IN THIS RELEASE)
+  this provides a more composable API. You can says things like this:
+
+        assert match("xyz.png")
+        assert not match("xyz.png")
+        assert match("a.png") and match("b.png") and not match("c.png")
+        assert wait_until(lambda: not match("xyz.png"))
+        assert match_text("Main menu")
+        # etc.
+
+    There are drawbacks to using `assert` instead of `wait_for_match`:
+
+    * The exception message won't contain the reason why the match
+      failed (unless you specify it as a second parameter to `assert`,
+      which is tedious and we don't expect you to do it), and
+    * The exception won't have the offending video-frame attached (so the
+      screenshot that `stbt batch run` saves alongside the failing test
+      logs will be a few frames later than the frame that actually caused
+      the test to fail).
+
+    We hope to solve both problems at some point in the future.
+
 ##### User-visible changes since 0.21
 
 * API: `is_frame_black()` now no longer requires a frame to be passed in.  If

--- a/stbt-run
+++ b/stbt-run
@@ -67,7 +67,7 @@ except Exception as e:  # pylint: disable=W0703
         stbt.save_frame(e.screenshot, "screenshot.png")
         sys.stderr.write("Saved screenshot to '%s'.\n" % ("screenshot.png"))
     traceback.print_exc(file=sys.stderr)
-    if isinstance(e, stbt.UITestFailure):
+    if isinstance(e, (stbt.UITestFailure, AssertionError)):
         sys.exit(1)  # Failure
     else:
         sys.exit(2)  # Error

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -1328,16 +1328,17 @@ def is_screen_black(frame=None, mask=None, threshold=None):
 
 @contextmanager
 def as_precondition(message):
-    """Context manager that replaces UITestFailures with UITestErrors.
+    """Context manager that replaces test failures with test errors.
 
     If you run your test scripts with stb-tester's batch runner, the reports it
-    generates will show test failures (that is, `UITestFailure` exceptions) as
-    red results, and unhandled exceptions of any other type as yellow results.
-    Note that `wait_for_match`, `wait_for_motion`, and similar functions raise
-    `UITestFailure` (red results) when they detect a failure. By running such
-    functions inside an `as_precondition` context, any `UITestFailure` (red)
-    they raise will be caught, and a `UITestError` (yellow) will be raised
-    instead.
+    generates will show test failures (that is, `stbt.UITestFailure` or
+    `AssertionError` exceptions) as red results, and test errors (that is,
+    unhandled exceptions of any other type) as yellow results. Note that
+    `wait_for_match`, `wait_for_motion`, and similar functions raise a
+    `stbt.UITestFailure` when they detect a failure. By running such functions
+    inside an `as_precondition` context, any `stbt.UITestFailure` or
+    `AssertionError` exceptions they raise will be caught, and a
+    `stbt.PreconditionError` will be raised instead.
 
     When running a single test script hundreds or thousands of times to
     reproduce an intermittent defect, it is helpful to mark unrelated failures
@@ -1361,10 +1362,10 @@ def as_precondition(message):
     """
     try:
         yield
-    except UITestFailure as e:
-        debug("stbt.as_precondition caught a UITestFailure exception and will "
+    except (UITestFailure, AssertionError) as e:
+        debug("stbt.as_precondition caught a %s exception and will "
               "re-raise it as PreconditionError.\nOriginal exception was:\n%s"
-              % traceback.format_exc(e))
+              % (type(e).__name__, traceback.format_exc(e)))
         exc = PreconditionError(message, e)
         if hasattr(e, 'screenshot'):
             exc.screenshot = e.screenshot  # pylint: disable=W0201

--- a/tests/test-stbt-run.sh
+++ b/tests/test-stbt-run.sh
@@ -53,6 +53,17 @@ test_stbt_run_return_code_on_precondition_error() {
         test.log
 }
 
+test_that_stbt_run_treats_failing_assertions_as_test_errors() {
+    local ret
+    cat > test.py <<-EOF
+	assert False, "My assertion"
+	EOF
+    stbt run -v test.py &> test.log
+    ret=$?
+    [[ $ret == 1 ]] || fail "Unexpected return code $ret (expected 2)"
+    assert grep -q "FAIL: test.py: AssertionError: My assertion" test.log
+}
+
 test_that_stbt_run_saves_screenshot_on_match_timeout() {
     cat > test.py <<-EOF
 	wait_for_match(


### PR DESCRIPTION
This brings stb-tester in line with traditional testing frameworks like
nose and pytest. Along with the introduction of `match()` in 33e8e356
and (in a future commit) `wait_until()`, this is part of a drive to
provide a more composible API. You can say things like:

* `assert match("xyz.png")`
* `assert not match("xyz.png")`
* `assert match("a.png") and match("b.png") and not match("c.png")`
* `assert wait_until(lambda: not match("xyz.png"))`
* `assert match_text("Main menu")`
* etc.

There are drawbacks to using `assert` instead of `wait_for_match`:

* The exception message won't contain the reason why the match
  failed (unless you specify it as a second parameter to `assert`,
  which is tedious and we don't expect you to do it), and
* The exception won't have the offending video-frame attached (so the
  screenshot that `stbt batch run` saves alongside the failing test
  logs will be a few frames later than the frame that actually caused
  the test to fail).

We hope to solve both problems at some point in the future: the first
one by using pytest and its assertion introspection[1] (which rewrites
python modules on import to provide the additional information on
assertion failures), and the second one by extending pytest's
module-rewriting to attach the video frame to the AssertionError.

[1] http://pytest.org/latest/assert.html#advanced-assertion-introspection