### PR TITLE
Add stbt.wait_until helper function

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -848,6 +848,59 @@ wait_for_motion(timeout_secs=10, consecutive_frames=None, noise_threshold=None, 
       to search for motion. White pixels select the area to search; black
       pixels the area to ignore.
 
+wait_until(callable_, timeout_secs=10, interval_secs=0)
+    Wait until a condition becomes true, or until a timeout.
+
+    `callable_` is any python callable, such as a function or a lambda
+    expression. It will be called repeatedly (with a delay of `interval_secs`
+    seconds between successive calls) until it succeeds (that is, it returns a
+    truthy value) or until `timeout_secs` seconds have passed. In both cases,
+    `wait_until` returns the value that `callable_` returns.
+
+    After you send a remote-control signal to the system-under-test it usually
+    takes a few frames to react, so a test script like this would probably
+    fail:
+
+        stbt.press("guide")
+        assert match("guide.png")
+
+    Instead, use this:
+
+        stbt.press("guide")
+        assert wait_until(lambda: match("guide.png"))
+
+    Note that instead of the above `assert wait_until(...)` you could use
+    `wait_for_match("guide.png")`. `wait_until` is a generic solution that
+    also works with stbt's other functions, like `match_text` and
+    `is_screen_black`.
+
+    `wait_until` also allows composing more complex conditions, such as:
+
+        # Wait until something disappears
+        assert wait_until(lambda: not match("xyz.png"))
+
+        # Assert that something doesn't appear within 10 seconds
+        assert not wait_until(lambda: match("xyz.png"))
+
+        # Assert that two images are present at the same time:
+        assert wait_until(lambda: match("a.png") and match("b.png"))
+
+        # Wait but don't raise an exception:
+        if not wait_until(lambda: match("xyz.png")):
+            do_something_else()
+
+    There are some drawbacks to using `assert` instead of `wait_for_match`:
+
+    * The exception message won't contain the reason why the match failed
+      (unless you specify it as a second parameter to `assert`, which is
+      tedious and we don't expect you to do it), and
+    * The exception won't have the offending video-frame attached (so the
+      screenshot that `stbt batch run` saves alongside the failing test logs
+      will be a few frames later than the frame that actually caused the test
+      to fail).
+
+    We hope to solve both of the above drawbacks at some point in the future.
+
 
 .. <end python docs>
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -31,29 +31,17 @@ For installation instructions see
 
 * `stbt run` and `stbt batch run` treat `AssertionError`s as test failures, not
   test errors. Along with the introduction of `match` in stb-tester 0.21 and
-  `wait_until` in this release, (TODO: MAKE SURE THIS HAPPENS IN THIS RELEASE)
-  this provides a more composable API. You can says things like this:
-
-        assert match("xyz.png")
-        assert not match("xyz.png")
-        assert match("a.png") and match("b.png") and not match("c.png")
-        assert wait_until(lambda: not match("xyz.png"))
-        assert match_text("Main menu")
-        # etc.
-
-    There are drawbacks to using `assert` instead of `wait_for_match`:
-
-    * The exception message won't contain the reason why the match
-      failed (unless you specify it as a second parameter to `assert`,
-      which is tedious and we don't expect you to do it), and
-    * The exception won't have the offending video-frame attached (so the
-      screenshot that `stbt batch run` saves alongside the failing test
-      logs will be a few frames later than the frame that actually caused
-      the test to fail).
-
-    We hope to solve both problems at some point in the future.
+  `wait_until` in this release, this provides a more composable API. See the
+  documentation for `wait_until` for more details.
 
 ##### User-visible changes since 0.21
+
+* API: New function `wait_until` runs any given function or lambda expression
+  until it succeeds, or until a timeout. This provides the waiting behaviour of
+  `wait_for_match`, but more general -- you can use it to look for a match or
+  the absence of a match, you can use it with `match_text`, `is_screen_black`,
+  user-defined functions, etc. See the [API documentation](
+  http://stb-tester.com/stbt.html#wait_until) for more details.
 
 * API: `is_frame_black()` now no longer requires a frame to be passed in.  If
   one is not specified it will be grabbed from live video, much like `match()`.

--- a/stbt/__init__.py
+++ b/stbt/__init__.py
@@ -72,6 +72,7 @@ __all__ = [
     "UITestFailure",
     "wait_for_match",
     "wait_for_motion",
+    "wait_until",
 ]
 
 if getattr(gi, "version_info", (0, 0, 0)) < (3, 12, 0):
@@ -1324,6 +1325,88 @@ def is_screen_black(frame=None, mask=None, threshold=None):
             _log_image(greyframe, 'non-black-regions-after-masking',
                        'stbt-debug/is_screen_black')
     return maxVal == 0
+
+
+def wait_until(callable_, timeout_secs=10, interval_secs=0):
+    """Wait until a condition becomes true, or until a timeout.
+
+    `callable_` is any python callable, such as a function or a lambda
+    expression. It will be called repeatedly (with a delay of `interval_secs`
+    seconds between successive calls) until it succeeds (that is, it returns a
+    truthy value) or until `timeout_secs` seconds have passed. In both cases,
+    `wait_until` returns the value that `callable_` returns.
+
+    After you send a remote-control signal to the system-under-test it usually
+    takes a few frames to react, so a test script like this would probably
+    fail:
+
+        stbt.press("guide")
+        assert match("guide.png")
+
+    Instead, use this:
+
+        stbt.press("guide")
+        assert wait_until(lambda: match("guide.png"))
+
+    Note that instead of the above `assert wait_until(...)` you could use
+    `wait_for_match("guide.png")`. `wait_until` is a generic solution that
+    also works with stbt's other functions, like `match_text` and
+    `is_screen_black`.
+
+    `wait_until` also allows composing more complex conditions, such as:
+
+        # Wait until something disappears
+        assert wait_until(lambda: not match("xyz.png"))
+
+        # Assert that something doesn't appear within 10 seconds
+        assert not wait_until(lambda: match("xyz.png"))
+
+        # Assert that two images are present at the same time:
+        assert wait_until(lambda: match("a.png") and match("b.png"))
+
+        # Wait but don't raise an exception:
+        if not wait_until(lambda: match("xyz.png")):
+            do_something_else()
+
+    There are some drawbacks to using `assert` instead of `wait_for_match`:
+
+    * The exception message won't contain the reason why the match failed
+      (unless you specify it as a second parameter to `assert`, which is
+      tedious and we don't expect you to do it), and
+    * The exception won't have the offending video-frame attached (so the
+      screenshot that `stbt batch run` saves alongside the failing test logs
+      will be a few frames later than the frame that actually caused the test
+      to fail).
+
+    We hope to solve both of the above drawbacks at some point in the future.
+    """
+    expiry_time = time.time() + timeout_secs
+    while True:
+        e = callable_()
+        if e:
+            return e
+        if time.time() > expiry_time:
+            debug("wait_until timed out: %s" % _callable_description(callable_))
+            return e
+        time.sleep(interval_secs)
+
+
+def _callable_description(callable_):
+    """Helper to provide nicer debug output when `wait_until` fails.
+
+    >>> _callable_description(wait_until)
+    'wait_until'
+    >>> _callable_description(
+    ...     lambda: stbt.press("OK"))
+    '    lambda: stbt.press("OK"))\\n'
+    """
+    d = callable_.__name__
+    if d == "<lambda>":
+        try:
+            d = inspect.getsource(callable_)
+        except IOError:
+            pass
+    return d
 
 
 @contextmanager

--- a/tests/test-stbt-py.sh
+++ b/tests/test-stbt-py.sh
@@ -263,6 +263,32 @@ test_that_is_screen_black_with_mask_writes_debugging_information() {
         || fail "source debug image not written"
 }
 
+test_that_wait_until_returns_on_success() {
+    cat > test.py <<-EOF
+	import stbt
+	count = 0
+	def t():
+	    global count
+	    count += 1
+	    return True
+	assert stbt.wait_until(t)
+	assert count == 1, "Unexpected count %d" % count
+	EOF
+    stbt run -v test.py
+}
+
+test_that_wait_until_times_out() {
+    cat > test.py <<-EOF
+	import time, stbt
+	start = time.time()
+	assert not stbt.wait_until(lambda: False, timeout_secs=1)
+	end = time.time()
+	assert 1 < end - start < 2, \
+	    "wait_until took too long (%ds)" % (end - start)
+	EOF
+    stbt run -v test.py
+}
+
 test_that_video_index_is_written_on_eos() {
     which webminspector.py &>/dev/null \
         || skip "webminspector.py not found. See https://chromium.googlesource.com/webm/webminspector/"


### PR DESCRIPTION
`wait_until` runs a function or lambda until it succeeds, or until a
timeout. See the function documentation in README.rst and
release-notes.md for details.

We have been using this function in one of our clients' test-pack
codebase for 6+ months now, and we use it in almost every single
testcase.