### PR TITLE
stbt batch summary report: Hardcode column types for tablequeryjs

### DIFF
--- a/stbt-batch.d/templates/index.html
+++ b/stbt-batch.d/templates/index.html
@@ -83,6 +83,20 @@
         {% endfor %}
       </tr>
       </thead>
+      <!-- hidden row with unambiguous types for tablequeryjs: -->
+      <thead>
+      <tr style="display:none">
+        <td>1900-01-01 00:00:00</td>
+        <td>I hope this will only be interpreted as text</td>
+        <td>I hope this will only be interpreted as text</td>
+        <td>I hope this will only be interpreted as text</td>
+        <td>I hope this will only be interpreted as text</td>
+        <td>28:00:00</td>
+        {% for column in extra_columns %}
+          <td>I hope this will only be interpreted as text</td>
+        {% endfor %}
+      </tr>
+      </thead>
       <tbody>
       {% for run in runs %}
       <tr class="{{run.css_class()}}">


### PR DESCRIPTION
tablequeryjs (the library we use for browser-side filtering of testrun
results) looks at the table's first row (after the headings) to
determine what each column's data type is. For this it uses momentjs,
a third-party library bundled by tablequeryjs.

Sometimes it gets it wrong. For example it thinks that a particular git
sha is a timestamp, and so you can't search for textual matches on the
"git sha" column.

Another (more serious) bug is that if the content of a table-cell
(in the first row after the headings) is longer than ~150 characters,
there's a null-dereference error somewhere deep in momentjs and the
entire page breaks, not just the search.

This seems to fix it. I'm not interested in writing an automated
regression test for it. At some point hopefully soon we're going to
implement server-side filtering (for other reasons, not specifically to
get rid of tablequeryjs, but it's likely that we won't be using
tablequeryjs at all so there's no point in spending too much effort on
this).

Fixes #257.

TODO

* [x] Fix table sorting by clicking on column header.
* [x] Test on Firefox.
* [x] Test on Chrome.
* [x] Test on Safari.
