### PR TITLE
_stbt.control: Support user-defined remote control types

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,6 +109,12 @@ Global options
     `--source-pipeline=videotestsrc`. A script like `press("18")` will change
     videotestsrc's pattern property (see `gst-inspect videotestsrc`).
 
+  user:<module>[.<attributes>].<callable>
+    A user-defined remote control from an external Python module.
+    `callable` is either a remote control class or a factory function that
+    returns a remote control instance. The remote control instance must provide
+    a `press(key)` method; `key` is passed from `stbt.press`.
+
   x11:<display>
     Send keypresses to a given X display using the xtest extension. Can be used
     with GStreamer's ximagesrc for testing desktop applications and websites.

--- a/_stbt/control.py
+++ b/_stbt/control.py
@@ -33,6 +33,7 @@ def uri_to_remote(uri, display=None):
              :(?P<output>\d+)
              :(?P<config>[^:]+)''', IRNetBoxRemote),
         (r'x11:(?P<display>.+)?', _X11Remote),
+        (r'user:(?P<module>[^\.]+)\.(?P<attributes>.+)', new_user_remote),
     ]
     for regex, factory in remotes:
         m = re.match(regex, uri, re.VERBOSE | re.IGNORECASE)
@@ -199,6 +200,19 @@ def new_tcp_lirc_remote(control_name, hostname=None, port=None):
     debug("TCPLircRemote: Connected to %s:%d" % (hostname, port))
 
     return LircRemote(control_name, _connect)
+
+
+def new_user_remote(module, attributes):
+    """Use a remote control from an external module."""
+    return _get_last_attr(__import__(module), attributes.split("."))()
+
+
+def _get_last_attr(obj, names):
+    """
+    >>> _get_last_attr(os, ["path", "join", "func_code", "co_name"])
+    'join'
+    """
+    return _get_last_attr(getattr(obj, names[0]), names[1:]) if names else obj
 
 
 class IRNetBoxRemote(object):

--- a/tests/test-stbt-control.sh
+++ b/tests/test-stbt-control.sh
@@ -61,3 +61,20 @@ test_stbt_control_as_stbt_record_control_recorder__keymap_from_config() {
     set_config control.keymap "$testdir/stbt-control.keymap" &&
     validate_stbt_record_control_recorder stbt-control
 }
+
+test_stbt_control_with_user_defined_control_type() {
+    cat > usercontrol.py <<-EOF &&
+	class UserControl(object):
+	    def press(self, key):
+	        print("UserControl: %s" % key)
+	EOF
+
+    cat > test.py <<-EOF &&
+	import stbt
+	stbt.press("ok")
+	EOF
+
+    PYTHONPATH="$PWD:$PYTHONPATH" stbt run -v \
+        --control "user:usercontrol.UserControl" test.py &&
+    cat log | grep "UserControl: ok"
+}


### PR DESCRIPTION
As all remote control types are defined in the private `_stbt.control`
module, it is not possible to use a custom control class without
modifying stb-tester.

Provide users of stb-tester a pluggable remote control type that allows
them to use their own remote control implementation from an external
module.

Usage:
```
stbt run --control user:mypackage.mymodule.MyRemoteControl test.py
```

Our use case for this feature: we'd like to use a custom factory for `IRNetBoxRemote`
that gets the set-top-box's manufacturer (and thus the config file to use) from an inventory
rather than the stbt config file.

As the public interface of a remote control is really simple - it
consists of a single `press(key)` function - I don't think it's
necessary to define an abstract base class that users should derive
their remote control class from.