### PR TITLE
New test for clock visualisation

### DIFF
--- a/tests/run-clock-test-forever.sh
+++ b/tests/run-clock-test-forever.sh
@@ -1,0 +1,13 @@
+trap 'echo -e "\nTotal: $i\nFailed: $f"; exit 2' sigint sigterm
+date
+i=0
+f=0
+while true; do
+    if timeout 10 ./run-tests.sh test_clock_visualisation >&2; then
+        echo -n .
+    else
+        echo -n F
+        f=$((f + 1))
+    fi
+    i=$((i + 1))
+done


### PR DESCRIPTION
A self-test for https://github.com/drothlis/stb-tester/commit/f77a67ea37fd975514aa9745c51d13e986e1f41a, addressing https://github.com/drothlis/stb-tester/pull/255#issuecomment-74672577.

The best outcome I could get was 5 failures out of 40000 test runs. If you have any idea how to make it more reliable, please help. How about skipping the test if the OCR fails? If it's only 0.01% of all executions then it shouldn't be a risk.