### PR TITLE
stbt run: Add the script's directory to PYTHONPATH

### DIFF
--- a/stbt-run
+++ b/stbt-run
@@ -54,10 +54,7 @@ def import_by_filename(filename_):
     if module_ext != '.py':
         raise ImportError("Invalid module filename '%s'" % filename_)
     sys.path = [os.path.abspath(module_dir)] + sys.path
-    try:
-        return __import__(module_name)
-    finally:
-        sys.path = sys.path[1:]
+    return __import__(module_name)
 
 try:
     # pylint: disable=W0611

--- a/tests/test-stbt-run.sh
+++ b/tests/test-stbt-run.sh
@@ -128,3 +128,18 @@ test_that_stbt_run_will_run_a_specific_function() {
     stbt run test.py::test_that_this_test_is_run
     [ -e "touched" ] || fail "Test not run"
 }
+
+test_that_relative_imports_work_when_stbt_run_runs_a_specific_function() {
+    mkdir tests
+    cat >tests/helpers.py <<-EOF
+	def my_helper():
+	    open("touched", "w").close()
+	EOF
+    cat >tests/test.py <<-EOF
+	def test_that_this_test_is_run():
+	    import helpers
+	    helpers.my_helper()
+	EOF
+    stbt run tests/test.py::test_that_this_test_is_run
+    [ -e "touched" ] || fail "Test not run"
+}


### PR DESCRIPTION
when running a test using the `script.py::function` scheme.  This makes `stbt run` behave more like `python script.py` and makes it easier to import other files in the same directory.

The old-style one test-script per file approach already does this.