### PR TITLE
Upgrade tablequeryjs to 0.18

### DIFF
--- a/stbt-batch.d/templates/index.html
+++ b/stbt-batch.d/templates/index.html
@@ -83,20 +83,6 @@
         {% endfor %}
       </tr>
       </thead>
-      <!-- hidden row with unambiguous types for tablequeryjs: -->
-      <thead>
-      <tr style="display:none">
-        <td>1900-01-01 00:00:00</td>
-        <td>I hope this will only be interpreted as text</td>
-        <td>I hope this will only be interpreted as text</td>
-        <td>I hope this will only be interpreted as text</td>
-        <td>I hope this will only be interpreted as text</td>
-        <td>28:00:00</td>
-        {% for column in extra_columns %}
-          <td>I hope this will only be interpreted as text</td>
-        {% endfor %}
-      </tr>
-      </thead>
       <tbody>
       {% for run in runs %}
       <tr class="{{run.css_class()}}">

--- a/stbt-batch.d/templates/index.html
+++ b/stbt-batch.d/templates/index.html
@@ -140,7 +140,7 @@
 
 <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js"></script>
 <script src="http://cdn.jsdelivr.net/sorttable/2/sorttable.js"></script>
-<script src="http://cdn.jsdelivr.net/jquery.tablequeryjs/0.1.5/tablequery.min.js"></script>
+<script src="http://cdn.jsdelivr.net/jquery.tablequeryjs/0.1.8/tablequery.min.js"></script>
 <script>
   $(document).ready(function() {
     $("#testruns tbody tr").not(".muted").on("click", select_testrun);
@@ -153,9 +153,7 @@
     update_totals();
     var search_string = decodeURIComponent(window.location.search.substring(1));
     if (search_string) {
-      $("#testruns_search_text").val(search_string);
-      // Hack until https://github.com/asimihsan/tablequeryjs/issues/18 fixed:
-      tablequery._table_search_text_on_keyup({}, search_string);
+      tablequery.set_filter(search_string);
     }
 
     function set_details_height() {


### PR DESCRIPTION
For bugfixes (https://github.com/asimihsan/tablequeryjs/issues/19 and
https://github.com/asimihsan/tablequeryjs/issues/21) and for
`set_filter` so we don't have to use undocumented internal tablequery
APIs.

This means I can revert #258 which was a bit of a hack.
